### PR TITLE
fix: Firebase auth 함수가 R8에 의해 난독화되던 문제 해결

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -85,3 +85,8 @@
 # kept. Suspend functions are wrapped in continuations where the type argument
 # is used.
 -keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
+
+# Firebase
+-keep public class com.google.firebase.** {*;}
+-keep class com.google.android.gms.internal.** {*;}
+-keepclasseswithmembers class com.google.firebase.FirebaseException


### PR DESCRIPTION
오랜만에 R8이 또..

```
-keep public class com.google.firebase.** {*;}
-keep class com.google.android.gms.internal.** {*;}
-keepclasseswithmembers class com.google.firebase.FirebaseException
```