### PR TITLE
일부 태블릿에서 구글 로그인 버튼이 보이지 않던 문제 해결

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -3,7 +3,20 @@
   <component name="deploymentTargetDropDown">
     <value>
       <entry key="app">
-        <State />
+        <State>
+          <runningDeviceTargetSelectedWithDropDown>
+            <Target>
+              <type value="RUNNING_DEVICE_TARGET" />
+              <deviceKey>
+                <Key>
+                  <type value="SERIAL_NUMBER" />
+                  <value value="adb-HA1KA0PD-ycfHsd._adb-tls-connect._tcp" />
+                </Key>
+              </deviceKey>
+            </Target>
+          </runningDeviceTargetSelectedWithDropDown>
+          <timeTargetWasSelectedWithDropDown value="2023-07-19T06:55:29.288439Z" />
+        </State>
       </entry>
     </value>
   </component>

--- a/README.md
+++ b/README.md
@@ -1,27 +1,43 @@
 [![Build Status](https://app.bitrise.io/app/a3b53150cc64506b/status.svg?token=QmWjAPkNDhHShc53zwJzmw&branch=main)](https://app.bitrise.io/app/a3b53150cc64506b)
 
-# 한빛 캘린더
+# 시각장애인 학생들을 위한 학사정보 앱
 
-한빛맹학교의 급식, 학사일정 정보를 알려주는 앱입니다. 안드로이드 기기 및 한소네에서 사용할 수 있습니다.
+전국 맹학교의 급식, 학사일정 등 학사일정 정보를 제공하는 앱입니다. 한소네를 포함한 모든 안드로이드 기기에서 사용할 수 있습니다.
 
 ## 다운로드
-<a href='https://play.google.com/store/apps/details?id=com.practice.hanbitlunch&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'><img alt='한빛 캘린더 다운로드하기 Google Play' width=250 src='https://play.google.com/intl/ko/badges/static/images/badges/ko_badge_web_generic.png'/></a>
+
+<a href='https://play.google.com/store/apps/details?id=com.practice.hanbitlunch&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'><img alt='블린더 다운로드하기 Google Play' width=250 src='https://play.google.com/intl/ko/badges/static/images/badges/ko_badge_web_generic.png'/></a>
 
 ## 주요 기능
+* **모든 기능에 시각장애인 접근성 고려 (저시력, 전맹 포함)**
 * 식단 및 학사일정 정보 제공
-* 시각장애인을 위한 접근성 구현 (TalkBack 지원)
+* 학사정보 검색 (예정)
+* 당일 식단 및 일정 알림 (예정)
+
+## 지원 학교
+* 한빛맹학교
+* 지원 학교는 계속 확대될 예정입니다.
 
 ## 스크린샷
-![image](https://user-images.githubusercontent.com/45386920/208619827-e36be4f1-33ca-4344-86ee-a35965585b9d.png)
+![앱 스크린샷](https://github.com/blinder-23/blindar-android/assets/45386920/ee6aa816-2f2e-447b-855b-b116b54a9c84)
+
+## Navigation Flow
+<img width="1879" alt="Android Navigation Flow" src="https://github.com/blinder-23/blindar-android/assets/45386920/6615312f-11b0-4dba-adc3-ca15a9628844">
 
 ## 기술 스택
-* [Jetpack Compose](https://developer.android.com/jetpack/compose)를 사용하여 UI를 작성했습니다.
-* [Android Architecture Guideline](https://developer.android.com/topic/architecture)을 준수하였습니다.
-* Androidx Room, ViewModel, WorkManager 등의 라이브러리를 사용했습니다.
-* 멀티 모듈 구조를 적용하여 빌드 시간을 단축하였습니다.
+* [Jetpack Compose](https://developer.android.com/jetpack/compose)
+* [Firebase](https://firebase.google.com/?hl=ko)
+* [Android Architecture Components](https://developer.android.com/topic/libraries/architecture?hl=ko) (Room, ViewModel, WorkManager 등)
+* [Retrofit](https://github.com/square/retrofit), [Gson](https://github.com/google/gson)
+* [KoreanLunarCalendar](https://github.com/usingsky/KoreanLunarCalendar)
+
+## 아키텍처
+[Android Architecture Guideline](https://developer.android.com/topic/architecture)을 준수했습니다.
 
 ## 모듈 구조
-![image](previews/dependency-graph-blindar.png)
+[Now in Android의 모듈 구조](https://github.com/android/nowinandroid/blob/main/docs/ModularizationLearningJourney.md)를 참고하여 구성했습니다.
+
+![모듈 구조 이미지](previews/dependency-graph-blindar.png)
 
 ## 연락처
 버그 제보 및 기능 개선 등 건의사항은 [이메일](mailto:blinder.contact@gmail.com)로 보내주세요.

--- a/core/designsystem/src/main/java/com/practice/designsystem/Annotations.kt
+++ b/core/designsystem/src/main/java/com/practice/designsystem/Annotations.kt
@@ -12,3 +12,10 @@ annotation class DarkPreview
 @LightPreview
 @DarkPreview
 annotation class LightAndDarkPreview
+
+@Preview(
+    name = "LightTablet",
+    showBackground = true,
+    device = "spec:width=1280dp,height=800dp,dpi=240"
+)
+annotation class LightTabletPreview

--- a/core/designsystem/src/main/java/com/practice/designsystem/Annotations.kt
+++ b/core/designsystem/src/main/java/com/practice/designsystem/Annotations.kt
@@ -6,8 +6,8 @@ import androidx.compose.ui.tooling.preview.Preview
 @Preview(name = "Light", showBackground = true)
 annotation class LightPreview
 
-annotation class DarkPreview
 @Preview(name = "Dark", showBackground = true, uiMode = UI_MODE_NIGHT_YES)
+annotation class DarkPreview
 
 @LightPreview
 @DarkPreview

--- a/feature/onboarding/src/main/java/com/practice/onboarding/onboarding/OnboardingScreen.kt
+++ b/feature/onboarding/src/main/java/com/practice/onboarding/onboarding/OnboardingScreen.kt
@@ -7,16 +7,8 @@ import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.CubicBezierEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.ElevatedButton
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.TextButton
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -37,6 +29,7 @@ import com.google.android.gms.auth.api.signin.GoogleSignInClient
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.google.firebase.auth.FirebaseUser
 import com.practice.designsystem.LightPreview
+import com.practice.designsystem.LightTabletPreview
 import com.practice.designsystem.components.AppIcon
 import com.practice.designsystem.components.TitleLarge
 import com.practice.designsystem.theme.BlindarTheme
@@ -80,44 +73,47 @@ fun OnboardingScreen(
         )
     }
 
-    val buttonFraction = 0.8f
-    ConstraintLayout(modifier = modifier) {
-        val (icon, phoneLoginButton, googleLoginButton) = createRefs()
-        AppIcon(
-            modifier = Modifier.constrainAs(icon) {
-                linkTo(
-                    start = parent.start,
-                    top = parent.top,
-                    end = parent.end,
-                    bottom = parent.bottom,
-                )
-                translationY = appIconOffset.value.dp
-            }
-        )
-        PhoneLoginButton(
-            onPhoneLogin = onPhoneLogin,
-            modifier = Modifier
-                .constrainAs(phoneLoginButton) {
-                    top.linkTo(icon.bottom, margin = 100.dp)
-                    start.linkTo(parent.start)
-                    end.linkTo(parent.end)
+    BoxWithConstraints(modifier = modifier) {
+        val buttonWidthRatio = if (minWidth < minHeight) 0.8f else 0.3f
+        ConstraintLayout(modifier = Modifier.fillMaxSize()) {
+            val buttonGuideline = createGuidelineFromBottom(0.1f)
+            val (icon, phoneLoginButton, googleLoginButton) = createRefs()
+            AppIcon(
+                modifier = Modifier.constrainAs(icon) {
+                    linkTo(
+                        start = parent.start,
+                        top = parent.top,
+                        end = parent.end,
+                        bottom = parent.bottom,
+                    )
+                    translationY = appIconOffset.value.dp
                 }
-                .fillMaxWidth(fraction = buttonFraction)
-                .alpha(buttonAlpha.value),
-        )
-        GoogleLoginButton(
-            onGoogleLogin = {
-                startForResult.launch(googleSignInClient.signInIntent)
-            },
-            modifier = Modifier
-                .constrainAs(googleLoginButton) {
-                    start.linkTo(parent.start)
-                    top.linkTo(phoneLoginButton.bottom, margin = 30.dp)
-                    end.linkTo(parent.end)
-                }
-                .fillMaxWidth(fraction = buttonFraction)
-                .alpha(buttonAlpha.value),
-        )
+            )
+            PhoneLoginButton(
+                onPhoneLogin = onPhoneLogin,
+                modifier = Modifier
+                    .constrainAs(phoneLoginButton) {
+                        start.linkTo(parent.start)
+                        bottom.linkTo(googleLoginButton.top, margin = 20.dp)
+                        end.linkTo(parent.end)
+                    }
+                    .fillMaxWidth(fraction = buttonWidthRatio)
+                    .alpha(buttonAlpha.value),
+            )
+            GoogleLoginButton(
+                onGoogleLogin = {
+                    startForResult.launch(googleSignInClient.signInIntent)
+                },
+                modifier = Modifier
+                    .constrainAs(googleLoginButton) {
+                        start.linkTo(parent.start)
+                        bottom.linkTo(buttonGuideline)
+                        end.linkTo(parent.end)
+                    }
+                    .fillMaxWidth(fraction = buttonWidthRatio)
+                    .alpha(buttonAlpha.value),
+            )
+        }
     }
 }
 
@@ -201,6 +197,7 @@ private fun GoogleLoginButton(
 }
 
 @LightPreview
+@LightTabletPreview
 @Composable
 private fun OnboardingScreenPreview() {
     BlindarTheme {


### PR DESCRIPTION
closes #93.

# 원인

버튼의 위치가 하드코딩된 dp 값으로 지정되어 있어, 일부 기기에서 버튼이 너무 밑으로 내려가는 문제가 있었다.
```Kotlin
PhoneLoginButton(
    modifier = Modifier
        .constrainAs(phoneLoginButton) {
            top.linkTo(icon.bottom, margin = 100.dp)
            start.linkTo(parent.start)
            end.linkTo(parent.end)
        }
)
```

버튼 위치를 비율로 지정하면 문제를 해결할 수 있다. 구체적으로는 구글 로그인 버튼의 bottom line을 화면의 맨 밑에서 10% 올라온 위치로 지정하였다.