### PR TITLE
일부 입력창에 숫자만 입력할 수 있도록 수정

### DIFF
--- a/feature/register/src/main/java/com/practice/register/RegisterViewModel.kt
+++ b/feature/register/src/main/java/com/practice/register/RegisterViewModel.kt
@@ -14,6 +14,7 @@ import com.google.firebase.auth.PhoneAuthProvider
 import com.practice.api.school.RemoteSchoolRepository
 import com.practice.firebase.BlindarFirebase
 import com.practice.preferences.PreferencesRepository
+import com.practice.register.phonenumber.PhoneNumberValidator
 import com.practice.register.selectschool.School
 import com.practice.util.update
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -41,8 +42,9 @@ class RegisterViewModel @Inject constructor(
     }
 
     fun onPhoneNumberChange(value: String) {
+        val digitsOnly = PhoneNumberValidator.filterOnlyDigits(value)
         registerUiState.update {
-            this.copy(phoneNumber = value)
+            this.copy(phoneNumber = digitsOnly)
         }
     }
 
@@ -136,9 +138,10 @@ class RegisterViewModel @Inject constructor(
     }
 
     fun onAuthCodeChange(value: String) {
-        if (value.length <= 6) {
+        val digitsOnly = PhoneNumberValidator.filterOnlyDigits(value)
+        if (digitsOnly.length <= 6) {
             registerUiState.update {
-                this.copy(authCode = value)
+                this.copy(authCode = digitsOnly)
             }
         }
     }

--- a/feature/register/src/main/java/com/practice/register/phonenumber/PhoneNumberValidator.kt
+++ b/feature/register/src/main/java/com/practice/register/phonenumber/PhoneNumberValidator.kt
@@ -5,4 +5,8 @@ object PhoneNumberValidator {
     fun validate(phoneNumber: String): Boolean {
         return regex.containsMatchIn(phoneNumber)
     }
+
+    fun filterOnlyDigits(value: String): String {
+        return value.filter { it.isDigit() }
+    }
 }

--- a/feature/register/src/test/java/com/practice/register/PhoneNumberValidatorTest.kt
+++ b/feature/register/src/test/java/com/practice/register/PhoneNumberValidatorTest.kt
@@ -1,10 +1,14 @@
 package com.practice.register
 
 import com.practice.register.phonenumber.PhoneNumberValidator
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Test
 
 class PhoneNumberValidatorTest {
+    /**
+     * validate phone number test
+     */
 
     @Test
     fun nonDigitsOnly() {
@@ -49,5 +53,31 @@ class PhoneNumberValidatorTest {
     @Test
     fun suffix_matches() {
         assertFalse(PhoneNumberValidator.validate("001012345678"))
+    }
+
+    /**
+     * filter only digits test
+     */
+    @Test
+    fun emptyString() {
+        assertThat(PhoneNumberValidator.filterOnlyDigits("")).isEqualTo("")
+    }
+
+    @Test
+    fun digitsString() {
+        val string = "0123456789"
+        assertThat(PhoneNumberValidator.filterOnlyDigits(string)).isEqualTo(string)
+    }
+
+    @Test
+    fun asciiCharacterString() {
+        val string = "012a345er67.;89"
+        assertThat(PhoneNumberValidator.filterOnlyDigits(string)).isEqualTo("0123456789")
+    }
+
+    @Test
+    fun unicodeCharacterString() {
+        val string = "0123456가7닭89"
+        assertThat(PhoneNumberValidator.filterOnlyDigits(string)).isEqualTo("0123456789")
     }
 }


### PR DESCRIPTION
전화번호, 인증코드 입력 창에 숫자만 입력할 수 있도록 수정하였다. 

스마트폰에서는 숫자 키보드만 보이므로 다른 문자를 입력할 수 없었지만, 붙여넣기나 한소네 키보드 등으로 숫자가 아닌 문자를 입력할 수 있었다. 따라서 이 PR에서는 아예 UI state를 업데이트할 때 숫자만 필터링하도록 수정하였다.

closes #95.