### PR TITLE
fix: 학교 선택 항목에 라벨이 없던 문제 해결

### DIFF
--- a/core/designsystem/src/main/java/com/practice/designsystem/components/Text.kt
+++ b/core/designsystem/src/main/java/com/practice/designsystem/components/Text.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.TextUnit
 import com.practice.designsystem.theme.NanumSquareRound
 
@@ -197,7 +198,8 @@ fun LabelSmall(
 fun BodyLarge(
     text: String,
     modifier: Modifier = Modifier,
-    textColor: Color = MaterialTheme.colorScheme.onSurface
+    textColor: Color = MaterialTheme.colorScheme.onSurface,
+    textAlign: TextAlign? = null,
 ) {
     Text(
         text = text,
@@ -205,6 +207,7 @@ fun BodyLarge(
         style = MaterialTheme.typography.bodyLarge,
         color = textColor,
         fontFamily = NanumSquareRound,
+        textAlign = textAlign,
     )
 }
 

--- a/feature/register/src/main/java/com/practice/register/selectschool/SchoolList.kt
+++ b/feature/register/src/main/java/com/practice/register/selectschool/SchoolList.kt
@@ -1,17 +1,16 @@
 package com.practice.register.selectschool
 
 import androidx.compose.foundation.ScrollState
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.ListItem
-import androidx.compose.material3.ListItemDefaults
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.practice.designsystem.LightPreview
 import com.practice.designsystem.components.BodyLarge
@@ -47,10 +46,23 @@ private fun SchoolItem(
 ) {
     ListItem(
         headlineContent = {
-            BodyLarge(text = school.name)
+            TextButton(
+                onClick = { onClick(school) },
+                colors = ButtonDefaults.textButtonColors(
+                    containerColor = MaterialTheme.colorScheme.surface,
+                    contentColor = MaterialTheme.colorScheme.onSurface,
+                ),
+                modifier = Modifier.fillMaxWidth(),
+                contentPadding = PaddingValues(0.dp),
+            ) {
+                BodyLarge(
+                    text = school.name,
+                    textAlign = TextAlign.Start,
+                    modifier = Modifier.weight(1f),
+                )
+            }
         },
-        modifier = modifier
-            .clickable { onClick(school) },
+        modifier = modifier,
         colors = ListItemDefaults.colors(
             containerColor = MaterialTheme.colorScheme.surface,
             headlineColor = MaterialTheme.colorScheme.onSurface,


### PR DESCRIPTION
closes #96.

# 원인

학교 선택 항목은 `ListItem` 안에 headlineContent로 `BodyLarge` 텍스트를 넣는 방식으로 구성되어 있었는데, `BodyLarge`의 텍스트는 읽어주지만 `ListItem` 자체의 contentDescription이 없어서 라벨이 보이지 않았다.

# 해결법

라벨을 붙이는 동시에 버튼임을 명확히 드러내기 위해 headlineContent를 `TextButton`으로 변경하였다. 버튼 내부에는 동일한 `BodyLarge`가 들어간다.