### PR TITLE
feature: 날짜 선택 상태를 라벨로 더 자세히 알려줌

### DIFF
--- a/feature/main/src/main/java/com/practice/main/MainScreenViewModel.kt
+++ b/feature/main/src/main/java/com/practice/main/MainScreenViewModel.kt
@@ -11,16 +11,12 @@ import com.practice.combine.MealScheduleEntity
 import com.practice.designsystem.calendar.core.YearMonth
 import com.practice.designsystem.calendar.core.getFirstWeekday
 import com.practice.designsystem.calendar.core.yearMonth
-import com.practice.main.state.DailyMealScheduleState
-import com.practice.main.state.MainUiState
-import com.practice.main.state.MealUiState
-import com.practice.main.state.ScheduleUiState
-import com.practice.main.state.toMealUiState
-import com.practice.main.state.toSchedule
+import com.practice.main.state.*
 import com.practice.meal.entity.MealEntity
 import com.practice.preferences.PreferencesRepository
 import com.practice.preferences.ScreenMode
 import com.practice.schedule.entity.ScheduleEntity
+import com.practice.util.date.DateUtil
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.Dispatchers
@@ -186,16 +182,19 @@ class MainScreenViewModel @Inject constructor(
     }
 
     fun getContentDescription(date: Date): String {
-        return if (date == state.selectedDate) {
-            val dailyState = state.monthlyMealScheduleState.find { it.date == date }
-            if (dailyState != null) {
-                "식단: ${dailyState.mealUiState.description}\n학사일정:${dailyState.scheduleUiState.description}"
-            } else {
-                ""
-            }
+        val dailyState = state.monthlyMealScheduleState.find { it.date == date }
+
+        val isSelectedString = if (date == state.selectedDate) "선택됨" else ""
+        val isTodayString = if (date == DateUtil.today()) "오늘" else ""
+        val dailyStateString = if (dailyState != null) {
+            "식단: ${dailyState.mealUiState.description}\n학사일정:${dailyState.scheduleUiState.description}"
         } else {
             ""
         }
+
+        return listOf(isSelectedString, isTodayString, dailyStateString)
+            .filter { it.isNotEmpty() }
+            .joinToString(", ")
     }
 
     fun getClickLabel(date: Date): String =


### PR DESCRIPTION
# 문제 상황

기존에는 식단 및 학사일정 데이터만 읽어줬는데, 저시력 사용자의 피드백에 의하면 UI의 모든 내용을 라벨로 읽어줘야 한다. 따라서 이 날짜가 선택되었는지(테두리로 표시), 또는 이 날짜가 오늘인지를(배경색으로 표시) 라벨로도 알려줘야 한다.

# 해결 방법

라벨에 선택 여부와 오늘인지 아닌지 알려주는 문자열을 추가하였다. 형식은 다음과 같다.

`선택됨, 오늘, 7월 19일`

---

closes #97.