### PR TITLE
fix: System UI 뒤에 앱이 그려지던 문제 해결

### DIFF
--- a/app/src/main/java/com/practice/hanbitlunch/MainActivity.kt
+++ b/app/src/main/java/com/practice/hanbitlunch/MainActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.CompositionLocalProvider
@@ -39,7 +40,9 @@ class MainActivity : ComponentActivity() {
                 BlindarTheme {
                     BlindarNavHost(
                         windowSizeClass = windowSizeClass,
-                        modifier = Modifier.fillMaxSize(),
+                        modifier = Modifier
+                            .safeDrawingPadding()
+                            .fillMaxSize(),
                         googleSignInClient = getGoogleSignInClient(),
                     )
                 }

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -2,7 +2,8 @@
 <resources>
 
     <style name="Theme.Blindar" parent="android:Theme.Material.Light.NoActionBar">
-        <item name="android:statusBarColor">@color/surface</item>
+        <item name="android:statusBarColor">@color/fui_transparent</item>
+        <item name="android:navigationBarColor">@color/fui_transparent</item>
     </style>
 
     <style name="Theme.Blindar.SplashScreen" parent="Theme.SplashScreen">

--- a/feature/onboarding/src/main/java/com/practice/onboarding/onboarding/OnboardingScreen.kt
+++ b/feature/onboarding/src/main/java/com/practice/onboarding/onboarding/OnboardingScreen.kt
@@ -74,7 +74,7 @@ fun OnboardingScreen(
     }
 
     BoxWithConstraints(modifier = modifier) {
-        val buttonWidthRatio = if (minWidth < minHeight) 0.8f else 0.3f
+        val buttonWidthRatio = if (minWidth < minHeight) 0.8f else 0.5f
         ConstraintLayout(modifier = Modifier.fillMaxSize()) {
             val buttonGuideline = createGuidelineFromBottom(0.1f)
             val (icon, phoneLoginButton, googleLoginButton) = createRefs()

--- a/feature/onboarding/src/main/java/com/practice/onboarding/onboarding/OnboardingScreen.kt
+++ b/feature/onboarding/src/main/java/com/practice/onboarding/onboarding/OnboardingScreen.kt
@@ -76,7 +76,7 @@ fun OnboardingScreen(
     BoxWithConstraints(modifier = modifier) {
         val buttonWidthRatio = if (minWidth < minHeight) 0.8f else 0.5f
         ConstraintLayout(modifier = Modifier.fillMaxSize()) {
-            val buttonGuideline = createGuidelineFromBottom(0.1f)
+            val buttonGuideline = createGuidelineFromBottom(0.05f)
             val (icon, phoneLoginButton, googleLoginButton) = createRefs()
             AppIcon(
                 modifier = Modifier.constrainAs(icon) {


### PR DESCRIPTION
# 원인

[Window insets 적용 과정](https://developer.android.com/jetpack/compose/layouts/insets#insets-setup)을 마친 후 inset padding을 적용하지 않은 것이 문제였다. 

# 해결 방법

Insets padding을 최상위 Composable에 적용하면 된다. 이 PR에서는 가장 간단한 `Modifier.safeDrawingPadding()`을 적용하였다. 향후 더 복잡한 insets padding이 필요할 때 수정하면 된다.

closes #100.