### PR TITLE
fix: 기존 계정으로 구글 로그인 시 앱이 팅기던 문제 해결

### DIFF
--- a/core/firebase/src/main/java/com/practice/firebase/BlindarFirebase.kt
+++ b/core/firebase/src/main/java/com/practice/firebase/BlindarFirebase.kt
@@ -56,7 +56,7 @@ object BlindarFirebase {
         val user = task?.user
         val username = user?.displayName
         if (user != null && username != null) {
-            val schoolId = getSchoolId(username).value as String?
+            val schoolId = getSchoolId(username).value as? Long
             if (schoolId == null) {
                 // new user register
                 tryStoreUsername(


### PR DESCRIPTION
# 원인

정수형인 학교 ID를 `String?` 타입으로 캐스팅했다.

# 해결 방법

학교 ID를 `String?`이 아닌 `Long?`으로 형변환하도록 수정했다.

closes #108.