### PR TITLE
feature: 학교 선택 화면에서 학교를 가나다 순으로 정렬

### DIFF
--- a/core/api/src/main/java/com/practice/api/school/RemoteSchoolDataSourceImpl.kt
+++ b/core/api/src/main/java/com/practice/api/school/RemoteSchoolDataSourceImpl.kt
@@ -11,7 +11,7 @@ class RemoteSchoolDataSourceImpl @Inject constructor(private val api: SchoolApi)
         return try {
             api.getSupportedSchools().data.apply {
                 Log.d(TAG, "schools: ${this.map { it.schoolName }}")
-            }
+            }.sortedBy { it.schoolName }
         } catch (e: Exception) {
             Log.e(TAG, "School api error", e)
             emptyList()


### PR DESCRIPTION
## 문제 상황
학교 선택 화면에서 어떤 기준으로 학교가 나열된 건지 명확하지 않다. 사실 교육청 코드 순으로 정렬한 것이지만, 사용자가 이를 알 수 있는 방법은 없다.

## 해결 방법
정렬 순서를 명확히 전달하기 위해 `가나다 순`으로 정렬했다. 정렬 위치는 데이터가 지나가는 여러 data container 중 `RemoteSchoolDataSource`로 결정했다. `RemoteSchoolRepository`에서는 학교 리스트와 관련된 비즈니스 로직을 처리하는 데 집중하고, 데이터 자체를 조작하는 건 DataSource에 맡겼다.

## 수정한 내용
* 4e9d993badb15be4a0ac5ea6546a21aa20046669: `RemoteSchoolDataSource`에서 학교 목록을 가나다순으로 정렬하여 반환하도록 수정했다.
