### PR TITLE
feature: 배리어프리 공모전 지원 문구 작성

### DIFF
--- a/core/designsystem/src/main/java/com/practice/designsystem/components/Text.kt
+++ b/core/designsystem/src/main/java/com/practice/designsystem/components/Text.kt
@@ -169,6 +169,7 @@ fun LabelMedium(
     text: String,
     modifier: Modifier = Modifier,
     textColor: Color = MaterialTheme.colorScheme.onSurface,
+    textAlign: TextAlign? = null,
 ) {
     Text(
         text = text,
@@ -176,6 +177,7 @@ fun LabelMedium(
         style = MaterialTheme.typography.labelMedium,
         color = textColor,
         fontFamily = NanumSquareRound,
+        textAlign = textAlign,
     )
 }
 

--- a/feature/onboarding/src/main/java/com/practice/onboarding/splash/SplashScreen.kt
+++ b/feature/onboarding/src/main/java/com/practice/onboarding/splash/SplashScreen.kt
@@ -2,18 +2,24 @@ package com.practice.onboarding.splash
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.practice.designsystem.LightAndDarkPreview
 import com.practice.designsystem.components.AppIcon
+import com.practice.designsystem.components.LabelMedium
 import com.practice.designsystem.theme.BlindarTheme
 import com.practice.notification.BlindarNotificationManager
+import com.practice.onboarding.R
 import com.practice.user.UserRegisterState
 import com.practice.work.dailyalarm.DailyNotificationAlarmReceiver
 
@@ -45,8 +51,17 @@ fun SplashScreen(
         }
     }
 
+    SplashScreen(
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun SplashScreen(
+    modifier: Modifier = Modifier,
+) {
     ConstraintLayout(modifier = modifier) {
-        val (icon) = createRefs()
+        val (icon, supportText) = createRefs()
         AppIcon(
             modifier = Modifier.constrainAs(icon) {
                 linkTo(
@@ -57,7 +72,26 @@ fun SplashScreen(
                 )
             }
         )
+        SupportText(
+            modifier = Modifier
+                .padding(horizontal = 32.dp, vertical = 48.dp)
+                .constrainAs(supportText) {
+                    start.linkTo(parent.start)
+                    end.linkTo(parent.end)
+                    bottom.linkTo(parent.bottom)
+                }
+        )
     }
+}
+
+@Composable
+private fun SupportText(modifier: Modifier = Modifier) {
+    LabelMedium(
+        text = stringResource(id = R.string.received_support_text),
+        modifier = modifier,
+        textAlign = TextAlign.Center,
+        textColor = MaterialTheme.colorScheme.onSurface,
+    )
 }
 
 @LightAndDarkPreview
@@ -65,10 +99,6 @@ fun SplashScreen(
 private fun SplashScreenPreview() {
     BlindarTheme {
         SplashScreen(
-            onAutoLoginSuccess = {},
-            onUsernameNotSet = {},
-            onSchoolNotSelected = {},
-            onAutoLoginFail = {},
             modifier = Modifier
                 .fillMaxSize()
                 .background(MaterialTheme.colorScheme.surface),

--- a/feature/onboarding/src/main/java/com/practice/onboarding/splash/SplashScreen.kt
+++ b/feature/onboarding/src/main/java/com/practice/onboarding/splash/SplashScreen.kt
@@ -22,6 +22,7 @@ import com.practice.notification.BlindarNotificationManager
 import com.practice.onboarding.R
 import com.practice.user.UserRegisterState
 import com.practice.work.dailyalarm.DailyNotificationAlarmReceiver
+import kotlinx.coroutines.delay
 
 @Composable
 fun SplashScreen(
@@ -39,6 +40,7 @@ fun SplashScreen(
         systemUiController.setSystemBarsColor(systemBarColor)
         BlindarNotificationManager.createNotificationChannels(context)
         DailyNotificationAlarmReceiver.setInitialAlarm(context)
+        delay(300L) // SupportText를 충분히 오래 보여주기 위함
         when (viewModel.getUserRegisterState()) {
             UserRegisterState.NOT_LOGGED_IN -> onAutoLoginFail()
             UserRegisterState.USERNAME_MISSING -> onUsernameNotSet()

--- a/feature/onboarding/src/main/res/values/strings.xml
+++ b/feature/onboarding/src/main/res/values/strings.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="received_support_text">이 앱은 현대오토에버와 서울사회복지공동모금회의\n지원으로 제작되었습니다.</string>
+
     <string name="sign_in_with_phone">전화번호로 시작하기</string>
     <string name="sign_in_with_google">Google로 시작하기</string>
 </resources>


### PR DESCRIPTION
## 문제 상황

배리어프리 앱 개발 공모전의 규칙에 따라, `이 앱은 현대오토에버와 서울사회복지공동모금회의 지원으로 제작되었습니다.` 문구를 넣어야 한다.

## 해결 방법

스플래시 화면에 문구를 보이도록 했다. 단, 문구가 너무 빨리 지나가지 않게 300ms의 delay를 주었다.

## 수정한 내용

* https://github.com/blinder-23/blindar-android/commit/bab485ee42061bb8c569c4e14de1532c16b747ac: resource에 안내 문구  string 추가
* https://github.com/blinder-23/blindar-android/commit/da25cbbe7450f44e7ecc141630364ec43059fc0a: 안내 문구 composable 정의 및 UI에 추가
* https://github.com/blinder-23/blindar-android/commit/e5849c153653dc50b6265dac6058513d407e9330: 안내 문구가 너무 빨리 지나가지 않도록 delay 300ms 추가