### PR TITLE
피드백 전송 기능 추가

### DIFF
--- a/core/api/src/main/java/com/practice/api/di/feedback/FeedbackApiModule.kt
+++ b/core/api/src/main/java/com/practice/api/di/feedback/FeedbackApiModule.kt
@@ -1,0 +1,17 @@
+package com.practice.api.di.feedback
+
+import com.practice.api.feedback.FeedbackApi
+import com.practice.api.feedback.feedbackApi
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object FeedbackApiModule {
+    @Singleton
+    @Provides
+    fun provideFeedbackApi(): FeedbackApi = feedbackApi
+}

--- a/core/api/src/main/java/com/practice/api/di/feedback/RemoteFeedbackDataStoreModule.kt
+++ b/core/api/src/main/java/com/practice/api/di/feedback/RemoteFeedbackDataStoreModule.kt
@@ -1,0 +1,17 @@
+package com.practice.api.di.feedback
+
+import com.practice.api.feedback.RemoteFeedbackDataStore
+import com.practice.api.feedback.RemoteFeedbackDataStoreImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class RemoteFeedbackDataStoreModule {
+    @Binds
+    abstract fun bindRemoteFeedbackDataStore(
+        impl: RemoteFeedbackDataStoreImpl
+    ): RemoteFeedbackDataStore
+}

--- a/core/api/src/main/java/com/practice/api/di/feedback/RemoteFeedbackRepositoryModule.kt
+++ b/core/api/src/main/java/com/practice/api/di/feedback/RemoteFeedbackRepositoryModule.kt
@@ -1,0 +1,20 @@
+package com.practice.api.di.feedback
+
+import com.practice.api.feedback.RemoteFeedbackDataStore
+import com.practice.api.feedback.RemoteFeedbackRepository
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object RemoteFeedbackRepositoryModule {
+    @Singleton
+    @Provides
+    fun provideRemoteFeedbackRepository(
+        dataStore: RemoteFeedbackDataStore
+    ) = RemoteFeedbackRepository(dataStore)
+
+}

--- a/core/api/src/main/java/com/practice/api/feedback/FeedbackApi.kt
+++ b/core/api/src/main/java/com/practice/api/feedback/FeedbackApi.kt
@@ -1,0 +1,20 @@
+package com.practice.api.feedback
+
+import com.practice.api.BlindarRetrofit
+import com.practice.api.feedback.pojo.FeedbackRequestBody
+import okhttp3.ResponseBody
+import retrofit2.Response
+import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface FeedbackApi {
+    @POST("feedback")
+    suspend fun sendFeedback(
+        @Body body: FeedbackRequestBody,
+    ): Response<ResponseBody>
+}
+
+val feedbackApi: FeedbackApi
+    get() = BlindarRetrofit.getRetrofit(GsonConverterFactory.create())
+        .create(FeedbackApi::class.java)

--- a/core/api/src/main/java/com/practice/api/feedback/RemoteFeedbackDataStore.kt
+++ b/core/api/src/main/java/com/practice/api/feedback/RemoteFeedbackDataStore.kt
@@ -1,0 +1,11 @@
+package com.practice.api.feedback
+
+interface RemoteFeedbackDataStore {
+    suspend fun sendFeedback(
+        userId: String,
+        deviceName: String,
+        osVersion: String,
+        appVersion: String,
+        contents: String,
+    ): Int?
+}

--- a/core/api/src/main/java/com/practice/api/feedback/RemoteFeedbackDataStoreImpl.kt
+++ b/core/api/src/main/java/com/practice/api/feedback/RemoteFeedbackDataStoreImpl.kt
@@ -1,0 +1,43 @@
+package com.practice.api.feedback
+
+import android.util.Log
+import com.practice.api.feedback.pojo.FeedbackRequestBody
+import javax.inject.Inject
+
+class RemoteFeedbackDataStoreImpl @Inject constructor(private val api: FeedbackApi) : RemoteFeedbackDataStore {
+    override suspend fun sendFeedback(
+        userId: String,
+        deviceName: String,
+        osVersion: String,
+        appVersion: String,
+        contents: String
+    ): Int? {
+        val body = FeedbackRequestBody(userId, deviceName, osVersion, appVersion, contents)
+        return try {
+            val response = api.sendFeedback(body)
+            val code = response.code()
+            if (response.isSuccessful) {
+                log("Send feedback successfully!")
+            } else {
+                logError("Feedback error: code $code")
+            }
+            code
+        } catch (e: Exception) {
+            logError("api error: " + e.message)
+            e.printStackTrace()
+            null
+        }
+    }
+
+    private fun log(message: String) {
+        Log.d(TAG, message)
+    }
+
+    private fun logError(errorMessage: String) {
+        Log.e(TAG, errorMessage)
+    }
+
+    companion object {
+        private const val TAG = "FeedbackDataStoreImpl"
+    }
+}

--- a/core/api/src/main/java/com/practice/api/feedback/RemoteFeedbackRepository.kt
+++ b/core/api/src/main/java/com/practice/api/feedback/RemoteFeedbackRepository.kt
@@ -1,0 +1,28 @@
+package com.practice.api.feedback
+
+import com.practice.api.feedback.repository.FeedbackResult
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class RemoteFeedbackRepository(
+    private val dataStore: RemoteFeedbackDataStore,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+) {
+    suspend fun sendFeedback(
+        userId: String,
+        deviceName: String,
+        osVersion: String,
+        appVersion: String,
+        contents: String,
+    ): FeedbackResult {
+        return withContext(ioDispatcher) {
+            val code = dataStore.sendFeedback(userId, deviceName, osVersion, appVersion, contents)
+            if (code in 200 until 300) {
+                FeedbackResult.Success
+            } else {
+                FeedbackResult.Fail
+            }
+        }
+    }
+}

--- a/core/api/src/main/java/com/practice/api/feedback/pojo/FeedbackRequestBody.kt
+++ b/core/api/src/main/java/com/practice/api/feedback/pojo/FeedbackRequestBody.kt
@@ -1,0 +1,11 @@
+package com.practice.api.feedback.pojo
+
+import com.google.gson.annotations.SerializedName
+
+data class FeedbackRequestBody(
+    @SerializedName("user_id") val userId: String,
+    @SerializedName("device_name") val deviceName: String,
+    @SerializedName("os_version") val osVersion: String,
+    @SerializedName("app_version") val appVersion: String,
+    @SerializedName("contents") val contents: String,
+)

--- a/core/api/src/main/java/com/practice/api/feedback/repository/FeedbackResult.kt
+++ b/core/api/src/main/java/com/practice/api/feedback/repository/FeedbackResult.kt
@@ -1,0 +1,6 @@
+package com.practice.api.feedback.repository
+
+sealed class FeedbackResult {
+    object Success: FeedbackResult()
+    object Fail: FeedbackResult()
+}

--- a/core/api/src/test/java/com/practice/api/feedback/FeedbackApiTest.kt
+++ b/core/api/src/test/java/com/practice/api/feedback/FeedbackApiTest.kt
@@ -1,0 +1,22 @@
+package com.practice.api.feedback
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class FeedbackApiTest {
+    private val api = feedbackApi
+
+    @Test
+    fun testFeedbackApi() = runTest {
+        // TODO: 향후 테스트 서버 생기면 주석 해제하기
+//        val requestBody = FeedbackRequestBody(
+//            userId = "testId",
+//            deviceName = "testDevice",
+//            osVersion = "12",
+//            appVersion = "2.1.0",
+//            contents = "test feedback",
+//        )
+//        val result = api.sendFeedback(requestBody)
+//        assertThat(result.isSuccessful).isTrue()
+    }
+}

--- a/core/util/src/main/java/com/practice/util/ContextUtil.kt
+++ b/core/util/src/main/java/com/practice/util/ContextUtil.kt
@@ -1,0 +1,18 @@
+package com.practice.util
+
+import android.content.Context
+import android.content.pm.PackageManager.NameNotFoundException
+import android.util.Log
+
+fun Context.getAppVersionName(): String {
+    val tag = "ContextExt"
+    return try {
+        // Deprecated되지 않은 다른 함수가 API 33 이상을 요구하여 불가피하게 deprecated 함수를 사용
+        (packageManager.getPackageInfo(packageName, 0).versionName ?: "").apply {
+            Log.d(tag, "version name: $this")
+        }
+    } catch (e: NameNotFoundException) {
+        Log.e(tag, "package not found")
+        ""
+    }
+}

--- a/feature/main/src/main/java/com/practice/main/popup/FeedbackPopup.kt
+++ b/feature/main/src/main/java/com/practice/main/popup/FeedbackPopup.kt
@@ -1,0 +1,208 @@
+package com.practice.main.popup
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.contentColorFor
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import com.practice.designsystem.LightAndDarkPreview
+import com.practice.designsystem.LightPreview
+import com.practice.designsystem.components.BodySmall
+import com.practice.designsystem.components.LabelMedium
+import com.practice.designsystem.theme.BlindarTheme
+import com.practice.main.R
+import com.practice.main.popup.state.FeedbackPopupState
+import com.practice.main.popup.state.rememberFeedbackPopupState
+
+// TODO: Popup 형식 만들기?
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FeedbackPopup(
+    onSend: (String, String) -> Unit, // app version name, feedback contents
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+    state: FeedbackPopupState = rememberFeedbackPopupState(),
+) {
+    val onDismissWithState = {
+        onDismiss()
+        state.clear()
+    }
+
+    val shape = RoundedCornerShape(16.dp)
+    AlertDialog(
+        onDismissRequest = onDismissWithState,
+        modifier = modifier
+            .wrapContentHeight()
+            .shadow(4.dp, shape = shape)
+            .clip(shape)
+            .background(MaterialTheme.colorScheme.surface)
+    ) {
+        FeedbackPopupContent(
+            onSend = onSend,
+            onDismiss = onDismissWithState,
+            state = state,
+        )
+    }
+}
+
+@Composable
+private fun FeedbackPopupContent(
+    onSend: (String, String) -> Unit,
+    onDismiss: () -> Unit,
+    state: FeedbackPopupState,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val textColor = contentColorFor(backgroundColor = MaterialTheme.colorScheme.surface)
+
+    LazyColumn(
+        modifier = modifier,
+    ) {
+        item {
+            PopupTitleLarge(
+                text = stringResource(id = R.string.feedback_popup_title),
+                color = textColor,
+                modifier = Modifier.padding(16.dp)
+            )
+        }
+        item {
+            FeedbackTextField(
+                state = state,
+                modifier = Modifier.padding(horizontal = 16.dp),
+            )
+        }
+        item {
+            FeedbackPopupButtons(
+                onSend = { state.sendOnlyWhenTextIsNotEmpty(context, onSend) },
+                onDismiss = onDismiss,
+            )
+        }
+    }
+}
+
+@Composable
+private fun FeedbackTextField(
+    state: FeedbackPopupState,
+    modifier: Modifier = Modifier,
+) {
+    val focusManager = LocalFocusManager.current
+    val errorTextAlpha = if (state.isError) 1f else 0f
+    OutlinedTextField(
+        value = state.feedbackText,
+        onValueChange = state::onFeedbackTextUpdate,
+        isError = state.isError,
+        placeholder = {
+            BodySmall(
+                text = stringResource(id = R.string.feedback_popup_textfield_placeholder),
+                textColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+            )
+        },
+        supportingText = {
+            LabelMedium(
+                text = stringResource(id = R.string.feedback_popup_textfield_error_empty),
+                textColor = MaterialTheme.colorScheme.error,
+                modifier = Modifier.alpha(errorTextAlpha),
+            )
+        },
+        minLines = 4,
+        maxLines = 4,
+        colors = OutlinedTextFieldDefaults.colors(),
+        modifier = modifier.fillMaxWidth(),
+        keyboardActions = KeyboardActions(
+            onDone = { focusManager.clearFocus() },
+        ),
+        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+    )
+}
+
+@Composable
+private fun FeedbackPopupButtons(
+    onSend: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(modifier = modifier.wrapContentHeight()) {
+        FeedbackPopupButton(
+            text = stringResource(id = R.string.feedback_popup_cancel_button),
+            onClick = onDismiss,
+            modifier = Modifier.weight(1f),
+        )
+        FeedbackPopupButton(
+            text = stringResource(id = R.string.feedback_popup_send_button),
+            onClick = onSend,
+            modifier = Modifier
+                .weight(1f)
+                .background(MaterialTheme.colorScheme.primaryContainer),
+        )
+    }
+}
+
+@Composable
+private fun FeedbackPopupButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    TextButton(
+        onClick = onClick,
+        modifier = modifier,
+        shape = RoundedCornerShape(0.dp),
+    ) {
+        BodySmall(text = text)
+    }
+}
+
+@LightAndDarkPreview
+@Composable
+private fun FeedbackPopupPreview() {
+    BlindarTheme {
+        FeedbackPopup(
+            onSend = { _, _ ->
+
+            },
+            onDismiss = { },
+            modifier = Modifier
+                .padding(16.dp)
+                .fillMaxWidth(),
+        )
+    }
+}
+
+@LightPreview
+@Composable
+private fun FeedbackPopupErrorPreview() {
+    BlindarTheme {
+        FeedbackPopup(
+            onSend = { _, _ ->
+
+            },
+            onDismiss = { },
+            modifier = Modifier
+                .padding(16.dp)
+                .fillMaxWidth(),
+            state = rememberFeedbackPopupState(isError = true),
+        )
+    }
+}

--- a/feature/main/src/main/java/com/practice/main/popup/PopupComponents.kt
+++ b/feature/main/src/main/java/com/practice/main/popup/PopupComponents.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.unit.dp
 import com.practice.designsystem.LightAndDarkPreview
 import com.practice.designsystem.theme.BlindarTheme
@@ -51,12 +52,14 @@ fun PopupBodySmall(
     text: String,
     modifier: Modifier = Modifier,
     color: Color = Color.Unspecified,
+    fontStyle: FontStyle? = null,
 ) {
     PopupText(
         text = text,
         textStyle = PopupTypography.bodySmall,
         modifier = modifier,
         color = color,
+        fontStyle = fontStyle,
     )
 }
 
@@ -66,12 +69,14 @@ private fun PopupText(
     textStyle: TextStyle,
     modifier: Modifier = Modifier,
     color: Color = Color.Unspecified,
+    fontStyle: FontStyle? = null,
 ) {
     CompositionLocalProvider(LocalTextStyle provides textStyle) {
         Text(
             text = text,
             modifier = modifier,
             color = color,
+            fontStyle = fontStyle,
         )
     }
 }

--- a/feature/main/src/main/java/com/practice/main/popup/state/FeedbackPopupState.kt
+++ b/feature/main/src/main/java/com/practice/main/popup/state/FeedbackPopupState.kt
@@ -1,0 +1,59 @@
+package com.practice.main.popup.state
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import com.practice.util.getAppVersionName
+import kotlin.math.min
+
+@Stable
+class FeedbackPopupState internal constructor(feedbackText: String = "", isError: Boolean = false) {
+    var feedbackText by mutableStateOf(feedbackText)
+        private set
+
+    var isError: Boolean by mutableStateOf(isError)
+        private set
+
+    fun onFeedbackTextUpdate(value: String) {
+        feedbackText = value.substring(0..min(1000, value.lastIndex))
+        isError = false
+    }
+
+    fun onError() {
+        isError = true
+    }
+
+    fun clear() {
+        feedbackText = ""
+        isError = false
+    }
+
+    fun sendOnlyWhenTextIsNotEmpty(context: Context, onSend: (String, String) -> Unit) {
+        if (feedbackText.isEmpty()) {
+            onError()
+        } else {
+            val versionName = context.getAppVersionName()
+            onSend(versionName, feedbackText)
+        }
+    }
+
+    companion object {
+        internal val Saver = listSaver(
+            save = { listOf(it.feedbackText, it.isError) },
+            restore = { FeedbackPopupState(it[0] as String, it[1] as Boolean) }
+        )
+    }
+}
+
+@Composable
+fun rememberFeedbackPopupState(
+    feedbackText: String = "",
+    isError: Boolean = false,
+) = rememberSaveable(saver = FeedbackPopupState.Saver) {
+    FeedbackPopupState(feedbackText, isError)
+}

--- a/feature/main/src/main/res/values/strings.xml
+++ b/feature/main/src/main/res/values/strings.xml
@@ -30,4 +30,10 @@
     <string name="memo_popup_clear_text">%s 내용 지우기</string>
     <string name="memo_popup_item_delete">%s 삭제하기</string>
     <string name="memo_popup_close">닫기</string>
+
+    <string name="feedback_popup_title">피드백 보내기</string>
+    <string name="feedback_popup_textfield_placeholder">블린더 사용 후기를 알려주세요!</string>
+    <string name="feedback_popup_textfield_error_empty">피드백을 입력해 주세요.</string>
+    <string name="feedback_popup_cancel_button">취소</string>
+    <string name="feedback_popup_send_button">전송</string>
 </resources>


### PR DESCRIPTION
# 일반 PR
## 문제 상황

피드백을 전송할 수 있는 API를 미리 추가해 놓자.

## 해결 방법

피드백 API, DataStore, Repository를 추가하였다. `MainViewModel.sendFeedback()`에는 API request에 포함될 정보를 얻는 방법도 작성해 두었다.

피드백 팝업 composable을 작성하긴 했으나, 팝업은 사용하지 않을 예정이다. 피드백 작성 메뉴는 `설정` 화면에 들어갈 예정이다.

## 수정한 내용

* https://github.com/blinder-23/blindar-android/commit/edcf8f0dcf635e5530ee3fe89197de5d3ce12e61: 피드백 raw API 추가
* https://github.com/blinder-23/blindar-android/commit/1d4fe66d4fa9158a8abbcc132c37a0bb830b95b3: 피드백 팝업 composable 작성
* https://github.com/blinder-23/blindar-android/commit/93184d29d4d41c85725ee47b7fd0737e610cc4a6: 피드백 전송 로직을 `MainViewModel.sendFeedback()`에 추가