### PR TITLE
fix: screen insets 관련 문제 해결

### DIFF
--- a/app/src/main/java/com/practice/hanbitlunch/MainActivity.kt
+++ b/app/src/main/java/com/practice/hanbitlunch/MainActivity.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.CompositionLocalProvider
@@ -41,9 +40,12 @@ class MainActivity : ComponentActivity() {
                     BlindarNavHost(
                         windowSizeClass = windowSizeClass,
                         modifier = Modifier
-                            .safeDrawingPadding()
+//                            .safeDrawingPadding()
                             .fillMaxSize(),
                         googleSignInClient = getGoogleSignInClient(),
+                        onNavigateToMainScreen = {
+                            WindowCompat.setDecorFitsSystemWindows(window, true)
+                        }
                     )
                 }
             }

--- a/app/src/main/java/com/practice/hanbitlunch/screen/BlindarNavHost.kt
+++ b/app/src/main/java/com/practice/hanbitlunch/screen/BlindarNavHost.kt
@@ -43,10 +43,12 @@ fun BlindarNavHost(
     googleSignInClient: GoogleSignInClient,
     modifier: Modifier = Modifier,
     navController: NavHostController = rememberAnimatedNavController(),
+    onNavigateToMainScreen: () ->Unit = {},
 ) {
     val tweenSpec = tween<IntOffset>(
         durationMillis = 200,
     )
+
     AnimatedNavHost(
         navController = navController,
         startDestination = SPLASH,
@@ -83,6 +85,7 @@ fun BlindarNavHost(
             navController = navController,
             windowSizeClass = windowSizeClass,
             googleSignInClient = googleSignInClient,
+            onNavigateToMainScreen = onNavigateToMainScreen,
         )
     }
 }
@@ -92,6 +95,7 @@ fun NavGraphBuilder.blindarMainNavGraph(
     navController: NavHostController,
     windowSizeClass: WindowSizeClass,
     googleSignInClient: GoogleSignInClient,
+    onNavigateToMainScreen: () -> Unit,
 ) {
     val onLoginSuccess = {
         navController.navigate(MAIN) {
@@ -117,6 +121,7 @@ fun NavGraphBuilder.blindarMainNavGraph(
         SplashScreen(
             onAutoLoginSuccess = {
                 Log.d(TAG, "auto login success")
+                onNavigateToMainScreen()
                 onLoginSuccess()
             },
             onUsernameNotSet = onUsernameNotSet,
@@ -158,6 +163,7 @@ fun NavGraphBuilder.blindarMainNavGraph(
         navController = navController,
         onUsernameNotSet = onUsernameNotSet,
         onSchoolNotSelected = onSchoolNotSelected,
+        onNavigateToMainScreen = onNavigateToMainScreen,
     )
     composable(MAIN) {
         MainScreen(
@@ -176,6 +182,7 @@ fun NavGraphBuilder.registerGraph(
     navController: NavHostController,
     onUsernameNotSet: () -> Unit,
     onSchoolNotSelected: () -> Unit,
+    onNavigateToMainScreen: () -> Unit,
 ) {
     val onBackButtonClick: () -> Unit = { navController.popBackStack() }
     navigation(startDestination = VERIFY_PHONE, route = REGISTER) {
@@ -183,6 +190,7 @@ fun NavGraphBuilder.registerGraph(
             VerifyPhoneNumber(
                 onBackButtonClick = onBackButtonClick,
                 onExistingUserLogin = {
+                    onNavigateToMainScreen()
                     navController.navigate(MAIN) {
                         popUpTo(ONBOARDING) { inclusive = true }
                     }
@@ -213,6 +221,7 @@ fun NavGraphBuilder.registerGraph(
             SelectSchoolScreen(
                 onBackButtonClick = onBackButtonClick,
                 onNavigateToMain = {
+                    onNavigateToMainScreen()
                     navController.navigate(MAIN) {
                         popUpTo(ONBOARDING) { inclusive = true }
                         popUpTo(MAIN) { inclusive = true }

--- a/feature/register/src/main/java/com/practice/register/phonenumber/VerifyPhoneNumber.kt
+++ b/feature/register/src/main/java/com/practice/register/phonenumber/VerifyPhoneNumber.kt
@@ -6,12 +6,23 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.contentColorFor
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
@@ -21,13 +32,19 @@ import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.practice.designsystem.LightPreview
-import com.practice.designsystem.components.*
+import com.practice.designsystem.components.BlindarTopAppBar
+import com.practice.designsystem.components.BottomNextButton
+import com.practice.designsystem.components.LabelMedium
+import com.practice.designsystem.components.LabelSmall
+import com.practice.designsystem.components.TitleLarge
+import com.practice.designsystem.components.TitleSmall
 import com.practice.designsystem.theme.BlindarTheme
 import com.practice.register.R
 import com.practice.register.RegisterViewModel
 import com.practice.util.LocalActivity
 import com.practice.util.makeToast
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun VerifyPhoneNumber(
     onBackButtonClick: () -> Unit,
@@ -63,6 +80,12 @@ fun VerifyPhoneNumber(
         )
     }
 
+    val focusManager = LocalFocusManager.current
+    val hideKeyboardAndVerifyAuthCode = {
+        focusManager.clearFocus()
+        verifyAuthCode()
+    }
+
     ConstraintLayout(modifier = modifier) {
         val (appBar, phoneNumberCard, phoneNextButton) = createRefs()
         BlindarTopAppBar(
@@ -95,7 +118,7 @@ fun VerifyPhoneNumber(
             authCode = state.authCode,
             onAuthCodeChange = viewModel::onAuthCodeChange,
             isAuthCodeFieldEnabled = state.isAuthCodeFieldEnabled,
-            verifyAuthCode = verifyAuthCode,
+            verifyAuthCode = hideKeyboardAndVerifyAuthCode,
             modifier = Modifier
                 .constrainAs(phoneNumberCard) {
                     top.linkTo(appBar.bottom)
@@ -110,7 +133,7 @@ fun VerifyPhoneNumber(
         BottomNextButton(
             text = stringResource(R.string.next_button),
             enabled = state.isVerifyCodeButtonEnabled,
-            onClick = verifyAuthCode,
+            onClick = hideKeyboardAndVerifyAuthCode,
             modifier = Modifier
                 .constrainAs(phoneNextButton) {
                     bottom.linkTo(parent.bottom)


### PR DESCRIPTION
## 문제 상황

메모 입력 후 가상 키보드 때문에 줄어든 화면 크기가 전체 크기로 인식되어 달력 텍스트 크기가 줄어드는 문제가 있었다.

## 해결 방법

가상 키보드를 포함한 크기를 전체 화면으로 생각하게 한다. `WindowCompat.setDecorFitsSystemWindows(window, false)`를 해제하면 된다.

다만 휴대폰 인증, 닉네임 입력 화면에서는 가상 키보드를 제외한 화면이 전체 화면으로 생각되는 것이 UX가 더 좋으므로(`다음` 버튼이 보이므로) 메인 화면에 들어갈 때에만 `WindowCompat.setDecorFitsSystemWindows(window, true)` 코드를 적용하였다.

## 수정한 내용

* https://github.com/blinder-23/blindar-android/commit/07e7daa3001a86508b2e257cfc2f4219f83835c6: 휴대폰 인증 화면에서 `다음` 버튼을 누르면 키보드가 닫히도록 수정
* https://github.com/blinder-23/blindar-android/commit/a86340a8ed92d919432bb9f7051dc54fbb4b5845: 메인 화면에서 가상 키보드가 화면을 가린 후에 달력 글씨 크기가 작아지던 문제 해결