### PR TITLE
Feature/horizontal main screen

### DIFF
--- a/feature/main/src/main/java/com/practice/main/BlindarMainScreenElements.kt
+++ b/feature/main/src/main/java/com/practice/main/BlindarMainScreenElements.kt
@@ -83,8 +83,8 @@ fun MainScreenTopBar(
             textColor = MaterialTheme.colorScheme.onSurface,
             modifier = Modifier
                 .align(Alignment.Center)
-                .padding(16.dp)
-                .clickable(onClickLabel = onClickLabel, onClick = onClick),
+                .clickable(onClickLabel = onClickLabel, onClick = onClick)
+                .padding(horizontal = 16.dp, vertical = 12.dp),
         )
         DailyAlarmIcon(
             iconState = iconState,

--- a/feature/main/src/main/java/com/practice/main/HorizontalMainScreen.kt
+++ b/feature/main/src/main/java/com/practice/main/HorizontalMainScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -13,6 +14,7 @@ import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.CustomAccessibilityAction
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.hsk.ktx.date.Date
 import com.practice.designsystem.calendar.core.CalendarState
 import com.practice.designsystem.calendar.core.YearMonth
@@ -61,7 +63,10 @@ fun HorizontalMainScreen(
                 .fillMaxWidth()
                 .align(Alignment.CenterHorizontally)
         )
-        Row {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
             CalendarCard(
                 calendarPageCount = calendarPageCount,
                 modifier = Modifier.weight(1f),

--- a/feature/main/src/main/java/com/practice/main/HorizontalMainScreen.kt
+++ b/feature/main/src/main/java/com/practice/main/HorizontalMainScreen.kt
@@ -7,8 +7,10 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.CustomAccessibilityAction
 import androidx.compose.ui.tooling.preview.Preview
 import com.hsk.ktx.date.Date
@@ -35,12 +37,13 @@ fun HorizontalMainScreen(
     onScreenModeChange: (ScreenMode) -> Unit,
     calendarState: CalendarState,
     mealColumns: Int,
-    onAlarmIconClick: ()->Unit,
+    onAlarmIconClick: () -> Unit,
     onDateClick: (Date) -> Unit,
     onSwiped: (YearMonth) -> Unit,
     getContentDescription: (Date) -> String,
     getClickLabel: (Date) -> String,
     drawUnderlineToScheduleDate: DrawScope.(Date) -> Unit,
+    onNavigateToSelectSchoolScreen: () -> Unit,
     onNutrientPopupOpen: () -> Unit,
     onNutrientPopupClose: () -> Unit,
     onMemoPopupOpen: () -> Unit,
@@ -48,12 +51,15 @@ fun HorizontalMainScreen(
     customActions: (Date) -> ImmutableList<CustomAccessibilityAction> = { persistentListOf() },
 ) {
     Column(modifier = modifier) {
-        MainScreenHeader(
-            year = uiState.year,
-            month = uiState.month,
-            screenModeIconsEnabled = false,
-            selectedScreenMode = uiState.screenMode,
-            onScreenModeIconClick = onScreenModeChange,
+        MainScreenTopBar(
+            schoolName = uiState.selectedSchool.name,
+            onClick = onNavigateToSelectSchoolScreen,
+            onClickLabel = stringResource(id = R.string.navigate_to_school_select),
+            iconState = uiState.dailyAlarmIconState,
+            onAlarmIconClick = onAlarmIconClick,
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.CenterHorizontally)
         )
         Row {
             CalendarCard(
@@ -140,6 +146,7 @@ private fun HorizontalMainScreenPreview() {
             getContentDescription = { "" },
             getClickLabel = { "" },
             drawUnderlineToScheduleDate = {},
+            onNavigateToSelectSchoolScreen = {},
             onNutrientPopupOpen = {},
             onNutrientPopupClose = {},
             onMemoPopupOpen = {},

--- a/feature/main/src/main/java/com/practice/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/practice/main/MainScreen.kt
@@ -72,6 +72,7 @@ fun MainScreen(
                 getContentDescription = viewModel::getContentDescription,
                 getClickLabel = viewModel::getClickLabel,
                 drawUnderlineToScheduleDate = { },
+                onNavigateToSelectSchoolScreen = onNavigateToSelectSchoolScreen,
                 onNutrientPopupOpen = viewModel::openNutrientPopup,
                 onNutrientPopupClose = viewModel::closeNutrientPopup,
                 onMemoPopupOpen = viewModel::openMemoPopup,

--- a/feature/main/src/main/java/com/practice/main/MainScreenElements.kt
+++ b/feature/main/src/main/java/com/practice/main/MainScreenElements.kt
@@ -28,6 +28,7 @@ import androidx.compose.material.icons.filled.Cached
 import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -532,6 +533,7 @@ internal fun MainScreenContent(
     ElevatedCard(
         modifier = modifier
             .fillMaxWidth(),
+        elevation = CardDefaults.elevatedCardElevation(defaultElevation = 2.dp),
     ) {
         Column(
             modifier = Modifier


### PR DESCRIPTION
# 일반 PR
## 문제 상황

태블릿 등을 위한 가로 화면에 옛날 디자인이 적용되어 있다.

![image](https://github.com/blinder-23/blindar-android/assets/45386920/d2304f79-0d2b-47d5-89d2-fd583650d8b3)


## 해결 방법

새 디자인을 가로 화면에 적용하였다. 가로 화면의 특성을 살려 달력을 좌측, 컨텐츠를 우측에 배치하였다.

![Screenshot_1704093755](https://github.com/blinder-23/blindar-android/assets/45386920/605c2b50-50a0-4dea-a005-6308f6755b0d)

## 수정한 내용

* https://github.com/blinder-23/blindar-android/commit/22f421d23290f47bfc53bfa80b50167681ef0a8f: 가로 화면에 새 Top bar 적용
* https://github.com/blinder-23/blindar-android/commit/646798170bd80bad4175125fcbe5aa963314a8d0: Top bar의 학교 이름이 너무 좁은 영역에서만 클릭되던 문제를 해결했다. 클릭 영역에 padding을 줘서 더 넓은 영역이 클릭될 수 있게 하였다.
* https://github.com/blinder-23/blindar-android/commit/8e9108e01312ec7b79e434979b15eeb216162c13: 가로 화면에 padding과 horizontal spacing 등으로 간격을 주었다. 이전 화면은 너무 꽉 차 보이는 문제가 있었다.
* https://github.com/blinder-23/blindar-android/pull/140/commits/85439a56dc908620e2f2eb617dcd98a2e5d3de13: 식단, 학사일정을 보여주는 `ElevatedCard`에도 달력 `ElevatedCard`와 동일한 elevation을 적용했다. 이전에는 식단, 학사일정 카드의 elevation이 거의 없어 보이는 문제가 있었다.