### PR TITLE
gradle: 라이브러리 버전 업데이트

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,12 +20,12 @@ tasks.withType<KotlinCompile>().configureEach {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         applicationId = "com.practice.hanbitlunch"
         minSdk = 26
-        targetSdk = 33
+        targetSdk = 34
         versionCode = 1
         versionName = "2.2.0"
         signingConfig = signingConfigs.getByName("debug")
@@ -114,7 +114,7 @@ android {
     composeOptions {
         kotlinCompilerExtensionVersion = libs.versions.compose.compiler.get()
     }
-    packagingOptions {
+    packaging {
         resources {
             excludes.addAll(
                 arrayOf(

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
 
     <application
         android:name=".BlindarApplication"
@@ -19,7 +20,7 @@
         <!--        android:networkSecurityConfig="@xml/network_security_config">-->
         <profileable
             android:shell="true"
-            tools:targetApi="29" />
+            tools:targetApi="34" />
 
         <activity
             android:name=".MainActivity"

--- a/app/src/main/java/com/practice/hanbitlunch/BlindarApplication.kt
+++ b/app/src/main/java/com/practice/hanbitlunch/BlindarApplication.kt
@@ -12,8 +12,7 @@ class BlindarApplication : Application(), Configuration.Provider {
     @Inject
     lateinit var workerFactory: HiltWorkerFactory
 
-    override fun getWorkManagerConfiguration(): Configuration {
-        return Configuration.Builder().setWorkerFactory(workerFactory).build()
-    }
+    override val workManagerConfiguration: Configuration
+        get() = Configuration.Builder().setWorkerFactory(workerFactory).build()
 
 }

--- a/app/src/main/java/com/practice/hanbitlunch/screen/BlindarNavHost.kt
+++ b/app/src/main/java/com/practice/hanbitlunch/screen/BlindarNavHost.kt
@@ -1,7 +1,7 @@
 package com.practice.hanbitlunch.screen
 
 import android.util.Log
-import androidx.compose.animation.AnimatedContentScope
+import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
@@ -20,10 +20,10 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navigation
-import com.google.accompanist.navigation.animation.AnimatedNavHost
-import com.google.accompanist.navigation.animation.composable
-import com.google.accompanist.navigation.animation.rememberAnimatedNavController
 import com.google.android.gms.auth.api.signin.GoogleSignInClient
 import com.practice.hanbitlunch.R
 import com.practice.main.MainScreen
@@ -36,20 +36,19 @@ import com.practice.util.makeToast
 
 private val TAG = "BlindarNavHost"
 
-@OptIn(ExperimentalAnimationApi::class)
 @Composable
 fun BlindarNavHost(
     windowSizeClass: WindowSizeClass,
     googleSignInClient: GoogleSignInClient,
     modifier: Modifier = Modifier,
-    navController: NavHostController = rememberAnimatedNavController(),
-    onNavigateToMainScreen: () ->Unit = {},
+    navController: NavHostController = rememberNavController(),
+    onNavigateToMainScreen: () -> Unit = {},
 ) {
     val tweenSpec = tween<IntOffset>(
         durationMillis = 200,
     )
 
-    AnimatedNavHost(
+    NavHost(
         navController = navController,
         startDestination = SPLASH,
         modifier = modifier,
@@ -257,10 +256,9 @@ private fun priority(state: NavBackStackEntry) = when (state.route) {
     else -> 7
 }
 
-@OptIn(ExperimentalAnimationApi::class)
 private fun animationDirection(initialState: NavBackStackEntry, targetState: NavBackStackEntry) =
     if (priority(initialState) > priority(targetState)) {
-        AnimatedContentScope.SlideDirection.Right
+        AnimatedContentTransitionScope.SlideDirection.Right
     } else {
-        AnimatedContentScope.SlideDirection.Left
+        AnimatedContentTransitionScope.SlideDirection.Left
     }

--- a/benchmark/build.gradle.kts
+++ b/benchmark/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 android {
     namespace = "com.example.benchmark"
-    compileSdk = 33
+    compileSdk = 34
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
@@ -17,7 +17,7 @@ android {
 
     defaultConfig {
         minSdk = 26
-        targetSdk = 33
+        targetSdk = 34
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/benchmark/src/main/java/com/example/benchmark/BaselineProfileGenerator.kt
+++ b/benchmark/src/main/java/com/example/benchmark/BaselineProfileGenerator.kt
@@ -1,24 +1,27 @@
 package com.example.benchmark
 
-import androidx.benchmark.macro.ExperimentalBaselineProfilesApi
+import android.os.Build
 import androidx.benchmark.macro.junit4.BaselineProfileRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Rule
 import org.junit.runner.RunWith
 
-@ExperimentalBaselineProfilesApi
 @RunWith(AndroidJUnit4::class)
 class BaselineProfileGenerator {
     @get:Rule
-    val rule = BaselineProfileRule()
+    val rule = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+        BaselineProfileRule()
+    } else {
+        null
+    }
 
-    // Google API 없는 emulator에서 실행하자.
+    // Google API 없는 API 버전 33 이상 emulator에서 실행하자.
     // https://developer.android.com/topic/performance/baselineprofiles#creating-profile-rules
 
     // Baseline Profile을 생성할 때만 주석을 해제하자.
     // 평상시에는 androidTest에 영향을 주기 때문이다.
 //    @Test
-//    fun startUp() = rule.collectBaselineProfile(packageName = "com.example.hanbitlunch") {
+//    fun startUp() = rule?.collectBaselineProfile(packageName = "com.example.hanbitlunch") {
 //        pressHome()
 //        startActivityAndWait()
 //    }

--- a/core/api/build.gradle.kts
+++ b/core/api/build.gradle.kts
@@ -11,11 +11,11 @@ val url: String = gradleLocalProperties(rootDir).getProperty("server.url")
 
 android {
     namespace = "com.practice.api"
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 26
-        targetSdk = 33
+        targetSdk = 34
 
         testInstrumentationRunner = "com.practice.api.HiltTestRunner"
         consumerProguardFiles.add(File("consumer-rules.pro"))

--- a/core/api/build.gradle.kts
+++ b/core/api/build.gradle.kts
@@ -73,6 +73,9 @@ android {
     kotlinOptions {
         jvmTarget = "17"
     }
+    buildFeatures {
+        buildConfig = true
+    }
 }
 
 dependencies {

--- a/core/combine/build.gradle.kts
+++ b/core/combine/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "com.practice.combine"
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 26

--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 android {
     namespace = "com.practice.designsystem"
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 26

--- a/core/designsystem/src/main/java/com/practice/designsystem/calendar/SwipeableCalendar.kt
+++ b/core/designsystem/src/main/java/com/practice/designsystem/calendar/SwipeableCalendar.kt
@@ -30,7 +30,7 @@ import kotlinx.collections.immutable.persistentListOf
 fun SwipeableCalendar(
     itemCount: Int,
     modifier: Modifier = Modifier,
-    pagerState: PagerState = rememberPagerState(),
+    pagerState: PagerState = rememberPagerState { itemCount },
     calendarState: CalendarState = rememberCalendarState(),
     onDateClick: (Date) -> Unit = {},
     onPageChange: (Int) -> Unit = {},
@@ -57,7 +57,6 @@ fun SwipeableCalendar(
     }
 
     HorizontalPager(
-        pageCount = itemCount,
         state = pagerState,
         modifier = modifier
             .background(MaterialTheme.colorScheme.surface)

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 android {
     namespace = "com.practice.domain"
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 26

--- a/core/firebase/build.gradle.kts
+++ b/core/firebase/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 android {
     namespace = "com.practice.firebase"
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 26

--- a/core/preferences/build.gradle.kts
+++ b/core/preferences/build.gradle.kts
@@ -7,11 +7,11 @@ plugins {
 
 android {
     namespace = "com.practice.preferences"
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 26
-        targetSdk = 33
+        targetSdk = 34
 
         testInstrumentationRunner = "com.practice.preferences.HiltTestRunner"
         consumerProguardFiles.add(File("consumer-rules.pro"))

--- a/core/util/build.gradle.kts
+++ b/core/util/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 android {
     namespace = "com.practice.util"
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 26

--- a/core/work/build.gradle.kts
+++ b/core/work/build.gradle.kts
@@ -7,11 +7,11 @@ plugins {
 
 android {
     namespace = "com.example.work"
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 26
-        targetSdk = 33
+        targetSdk = 34
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles.add(File("consumer-rules.pro"))

--- a/data/meal/build.gradle.kts
+++ b/data/meal/build.gradle.kts
@@ -7,11 +7,11 @@ plugins {
 
 android {
     namespace = "com.practice.meal"
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 26
-        targetSdk = 33
+        targetSdk = 34
 
         testInstrumentationRunner = "com.practice.meal.util.HiltTestRunner"
         consumerProguardFiles.add(File("consumer-rules.pro"))

--- a/data/memo/build.gradle.kts
+++ b/data/memo/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "com.practice.memo"
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 26

--- a/data/schedule/build.gradle.kts
+++ b/data/schedule/build.gradle.kts
@@ -7,11 +7,11 @@ plugins {
 
 android {
     namespace = "com.practice.schedule"
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 26
-        targetSdk = 33
+        targetSdk = 34
 
         testInstrumentationRunner = "com.practice.schedule.util.HiltTestRunner"
         consumerProguardFiles.add(File("consumer-rules.pro"))

--- a/data/user/build.gradle.kts
+++ b/data/user/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "com.practice.user"
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 26

--- a/feature/main/build.gradle.kts
+++ b/feature/main/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "com.practice.main"
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 26

--- a/feature/onboarding/build.gradle.kts
+++ b/feature/onboarding/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "com.practice.onboarding"
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 26

--- a/feature/register/build.gradle.kts
+++ b/feature/register/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "com.practice.register"
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 26

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,5 +21,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-android.defaults.buildfeatures.buildconfig=true
 android.nonFinalResIds=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,22 +1,22 @@
 [versions]
 accompanist = '0.30.1'
-compose-bom = "2023.06.01"
+compose-bom = "2023.10.01"
 compose-compiler = '1.4.8'
-coroutines = "1.7.1"
-firebase-bom = "32.2.2"
-hilt = "2.46.1"
+coroutines = "1.7.3"
+firebase-bom = "32.7.0"
+hilt = "2.48"
 hsk-ktx = '1.0-beta14'
-junit5 = "5.9.2"
+junit5 = "5.9.3"
 kotlin = '1.8.22'
-lifecycle = '2.6.1'
+lifecycle = '2.6.2'
 retrofit = '2.9.0'
-room = "2.5.2"
+room = "2.6.1"
 violet-dreams = '0.1.2'
-navigation = '2.6.0'
-work = "2.8.1"
+navigation = '2.7.6'
+work = "2.9.0"
 
 [libraries]
-android-gradle = "com.android.tools.build:gradle:8.1.0"
+android-gradle = "com.android.tools.build:gradle:8.2.0"
 hilt-android-gradle-plugin = { module = 'com.google.dagger:hilt-android-gradle-plugin', version.ref = 'hilt' }
 kotlin-gradle-plugin = { module = 'org.jetbrains.kotlin:kotlin-gradle-plugin', version.ref = 'kotlin' }
 
@@ -30,7 +30,6 @@ violet-dreams-ui = { module = 'com.github.mwy3055.violet-dreams:violet-dreams-ui
 accompanist-drawablepainter = { module = 'com.google.accompanist:accompanist-drawablepainter', version.ref = 'accompanist' }
 accompanist-placeholder-material = { module = 'com.google.accompanist:accompanist-placeholder-material', version.ref = 'accompanist' }
 accompanist-systemuicontroller = { module = 'com.google.accompanist:accompanist-systemuicontroller', version.ref = 'accompanist' }
-accompanist-navigation-animation = { module = 'com.google.accompanist:accompanist-navigation-animation', version.ref = 'accompanist' }
 accompanist-permission = { module = 'com.google.accompanist:accompanist-permissions', version.ref = 'accompanist' }
 
 androidx-collection-ktx = 'androidx.collection:collection-ktx:1.2.0'
@@ -123,7 +122,6 @@ accompanist = [
     'accompanist-placeholder-material',
     'accompanist-systemuicontroller',
     'accompanist-drawablepainter',
-    'accompanist-navigation-animation',
     'accompanist-permission'
 ]
 android-test = ['androidx-junit', 'androidx-test-espresso-core']

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,8 +20,8 @@ android-gradle = "com.android.tools.build:gradle:8.2.0"
 hilt-android-gradle-plugin = { module = 'com.google.dagger:hilt-android-gradle-plugin', version.ref = 'hilt' }
 kotlin-gradle-plugin = { module = 'org.jetbrains.kotlin:kotlin-gradle-plugin', version.ref = 'kotlin' }
 
-firebase-crashlytics-gradle = 'com.google.firebase:firebase-crashlytics-gradle:2.9.8'
-google-services = 'com.google.gms:google-services:4.3.15'
+firebase-crashlytics-gradle = 'com.google.firebase:firebase-crashlytics-gradle:2.9.9'
+google-services = 'com.google.gms:google-services:4.4.0'
 
 hsk-ktx = { module = 'com.github.mwy3055:hsk-ktx', version.ref = 'hsk-ktx' }
 violet-dreams-core = { module = 'com.github.mwy3055.violet-dreams:violet-dreams-core', version.ref = 'violet-dreams' }
@@ -32,8 +32,8 @@ accompanist-placeholder-material = { module = 'com.google.accompanist:accompanis
 accompanist-systemuicontroller = { module = 'com.google.accompanist:accompanist-systemuicontroller', version.ref = 'accompanist' }
 accompanist-permission = { module = 'com.google.accompanist:accompanist-permissions', version.ref = 'accompanist' }
 
-androidx-collection-ktx = 'androidx.collection:collection-ktx:1.2.0'
-androidx-core-ktx = 'androidx.core:core-ktx:1.10.1'
+androidx-collection-ktx = 'androidx.collection:collection-ktx:1.3.0'
+androidx-core-ktx = 'androidx.core:core-ktx:1.12.0'
 androidx-palette-ktx = 'androidx.palette:palette-ktx:1.0.0'
 
 androidx-lifecycle-extensions = 'androidx.lifecycle:lifecycle-extensions:2.2.0'
@@ -47,8 +47,8 @@ androidx-work-testing = { module = 'androidx.work:work-testing', version.ref = '
 hilt-android = { module = 'com.google.dagger:hilt-android', version.ref = 'hilt' }
 hilt-android-testing = { module = 'com.google.dagger:hilt-android-testing', version.ref = 'hilt' }
 hilt-compiler = { module = 'com.google.dagger:hilt-compiler', version.ref = 'hilt' }
-hilt-compiler-androidx = 'androidx.hilt:hilt-compiler:1.0.0'
-hilt-work = 'androidx.hilt:hilt-work:1.0.0'
+hilt-compiler-androidx = 'androidx.hilt:hilt-compiler:1.1.0'
+hilt-work = 'androidx.hilt:hilt-work:1.1.0'
 
 room-compiler = { module = 'androidx.room:room-compiler', version.ref = 'room' }
 room-ktx = { module = 'androidx.room:room-ktx', version.ref = 'room' }
@@ -61,9 +61,9 @@ androidx-profileinstaller = 'androidx.profileinstaller:profileinstaller:1.3.1'
 androidx-startup-runtime = 'androidx.startup:startup-runtime:1.1.1'
 
 androidx-activity-compose = { module = 'androidx.activity:activity-compose' }
-androidx-hilt-navigation-compose = 'androidx.hilt:hilt-navigation-compose:1.0.0'
-androidx-lifecycle-viewmodel-compose = 'androidx.lifecycle:lifecycle-viewmodel-compose:2.6.1'
-androidx-paging-compose = 'androidx.paging:paging-compose:3.2.0'
+androidx-hilt-navigation-compose = 'androidx.hilt:hilt-navigation-compose:1.1.0'
+androidx-lifecycle-viewmodel-compose = 'androidx.lifecycle:lifecycle-viewmodel-compose:2.6.2'
+androidx-paging-compose = 'androidx.paging:paging-compose:3.2.1'
 androidx-navigation-compose = { module = 'androidx.navigation:navigation-compose', version.ref = 'navigation' }
 androidx-constraintlayout-compose = 'androidx.constraintlayout:constraintlayout-compose:1.0.1'
 
@@ -104,7 +104,7 @@ retrofit-coroutines-adapter = 'com.jakewharton.retrofit:retrofit2-kotlin-corouti
 junit-jupiter = { module = 'org.junit.jupiter:junit-jupiter', version.ref = 'junit5' }
 junit-vintage-engine = { module = 'org.junit.vintage:junit-vintage-engine', version.ref = 'junit5' }
 
-androidx-benchmark-macro-junit4 = 'androidx.benchmark:benchmark-macro-junit4:1.1.1'
+androidx-benchmark-macro-junit4 = 'androidx.benchmark:benchmark-macro-junit4:1.2.2'
 androidx-test-uiautomaker = 'androidx.test.uiautomator:uiautomator:2.2.0'
 
 androidx-test-orchestrator = 'androidx.test:orchestrator:1.4.2'
@@ -115,7 +115,7 @@ androidx-test-espresso-core = "androidx.test.espresso:espresso-core:3.5.0" # 절
 
 vanniktech-dependency-graph-generator = 'com.vanniktech:gradle-dependency-graph-generator-plugin:0.7.0'
 
-google-play-auth = 'com.google.android.gms:play-services-auth:20.6.0'
+google-play-auth = 'com.google.android.gms:play-services-auth:20.7.0'
 
 [bundles]
 accompanist = [

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,13 +1,13 @@
 [versions]
 accompanist = '0.30.1'
 compose-bom = "2023.10.01"
-compose-compiler = '1.4.8'
+compose-compiler = '1.5.1'
 coroutines = "1.7.3"
 firebase-bom = "32.7.0"
 hilt = "2.48"
 hsk-ktx = '1.0-beta14'
 junit5 = "5.9.3"
-kotlin = '1.8.22'
+kotlin = '1.9.0'
 lifecycle = '2.6.2'
 retrofit = '2.9.0'
 room = "2.6.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Feb 16 15:01:47 KST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## 문제 상황

라이브러리 버전이 노후화되어 최신 API를 사용할 수 없는 문제가 생겼다.

## 해결 방법

라이브러리, Compose Compiler 버전을 최신 버전으로 갱신했다. Android 14를 요구하는 라이브러리가 몇몇 있어 `targetSDK`도 34로 업데이트하였다.

## 수정한 내용

커밋 리스트 참고