### PR TITLE
fix: 학사일정 ID 타입을 Int에서 Long으로 변경

### DIFF
--- a/core/api/src/main/java/com/practice/api/schedule/FakeRemoteScheduleDataSource.kt
+++ b/core/api/src/main/java/com/practice/api/schedule/FakeRemoteScheduleDataSource.kt
@@ -9,7 +9,7 @@ class FakeRemoteScheduleDataSource : RemoteScheduleDataSource {
     private val data = (1..10).map {
         ScheduleModel(
             schoolCode = it,
-            id = it,
+            id = it.toLong(),
             date = Date(2022, it, 10).toEpochSecond(),
             title = "${it}번 학사일정",
             contents = "$it",

--- a/core/api/src/main/java/com/practice/api/schedule/pojo/ScheduleDeserializer.kt
+++ b/core/api/src/main/java/com/practice/api/schedule/pojo/ScheduleDeserializer.kt
@@ -22,7 +22,7 @@ class ScheduleDeserializer : JsonDeserializer<ScheduleResponse> {
             val element = it.asJsonObject
             ScheduleModel(
                 schoolCode = element.get("school_code").asInt,
-                id = element.get("id").asInt,
+                id = element.get("id").asLong,
                 date = element.get("date").asLong,
                 title = element.get("schedule").asString,
                 contents = element.get("contents").asString,

--- a/core/api/src/main/java/com/practice/api/schedule/pojo/ScheduleModel.kt
+++ b/core/api/src/main/java/com/practice/api/schedule/pojo/ScheduleModel.kt
@@ -4,7 +4,7 @@ import com.google.gson.annotations.SerializedName
 
 data class ScheduleModel(
     @SerializedName("school_code") val schoolCode: Int,
-    val id: Int,
+    val id: Long,
     val date: Long,
     @SerializedName("schedule") val title: String,
     val contents: String,

--- a/core/domain/src/main/java/com/practice/domain/schedule/Schedule.kt
+++ b/core/domain/src/main/java/com/practice/domain/schedule/Schedule.kt
@@ -2,7 +2,7 @@ package com.practice.domain.schedule
 
 data class Schedule(
     val schoolCode: Int,
-    val id: Int,
+    val id: Long,
     val year: Int,
     val month: Int,
     val day: Int,

--- a/data/schedule/src/main/java/com/practice/schedule/room/ScheduleEntityRoom.kt
+++ b/data/schedule/src/main/java/com/practice/schedule/room/ScheduleEntityRoom.kt
@@ -8,7 +8,7 @@ import com.practice.domain.schedule.Schedule
 @Entity(tableName = "schedule", primaryKeys = ["school_code", "id"])
 data class ScheduleEntityRoom(
     @ColumnInfo("school_code") val schoolCode: Int,
-    val id: Int,
+    val id: Long,
     @ColumnInfo(name = "date") val date: String,
     @ColumnInfo(name = "event_name") val eventName: String,
     @ColumnInfo(name = "event_content") val eventContent: String,

--- a/feature/main/src/main/java/com/practice/main/MainScreenElements.kt
+++ b/feature/main/src/main/java/com/practice/main/MainScreenElements.kt
@@ -668,7 +668,7 @@ val previewSchedules = (0..6).map {
         year = 2023,
         month = 7,
         day = it + 1,
-        id = it,
+        id = it.toLong(),
         eventName = "학사일정 $it",
         eventContent = "$it"
     )

--- a/feature/main/src/main/java/com/practice/main/popup/MemoPopup.kt
+++ b/feature/main/src/main/java/com/practice/main/popup/MemoPopup.kt
@@ -255,12 +255,11 @@ private fun CloseMemoPopupButton(
     }
 }
 
-// TODO: 프리뷰에 uiSchedule 추가하기, MemoItem(s)Preview 둘다 삭제 후 PopupPreview로 대체
 private val previewMemoPopupElements: ImmutableList<MemoPopupElement> = (1..4).map {
     if (it <= 2) {
         UiSchedule(
             schoolCode = 1,
-            id = it,
+            id = it.toLong(),
             year = 2023,
             month = 11,
             day = 13,

--- a/feature/main/src/main/java/com/practice/main/state/DailyData.kt
+++ b/feature/main/src/main/java/com/practice/main/state/DailyData.kt
@@ -41,7 +41,7 @@ data class DailyData(
                         year = 2022,
                         month = 10,
                         day = it,
-                        id = it,
+                        id = it.toLong(),
                         eventName = "제목 $it",
                         eventContent = "학사일정 $it",
                     )

--- a/feature/main/src/main/java/com/practice/main/state/ScheduleUiState.kt
+++ b/feature/main/src/main/java/com/practice/main/state/ScheduleUiState.kt
@@ -29,7 +29,7 @@ data class ScheduleUiState(
 
 data class UiSchedule(
     val schoolCode: Int,
-    val id: Int,
+    val id: Long,
     val year: Int,
     val month: Int,
     val day: Int,


### PR DESCRIPTION
## 문제 상황

학사일정 서버에서 Int 범위를 넘는 ID 값이 주어지는 경우가 있어, ID를 `Int`로 변환하려 시도하면 exception이 발생한다.

## 해결 방법

Kotlin 코드에서 학사일정 ID 타입을 `Long`으로 수정했다. Room은 주어지는 정수 값의 범위에 따라 자동으로 저장 타입을 결정하므로 수정할 필요가 없다.

## 수정한 내용
* https://github.com/blinder-23/blindar-android/commit/1ad039e46f277582ee291644e03f1e7baa0923c5: 학사일정과 관련된 Kotlin 클래스의 ID 타입을 Long으로 변경
