### PR TITLE
feature: 강제 데이터 새로고침 기능 추가

### DIFF
--- a/core/work/src/main/java/com/practice/work/BlindarWorkManager.kt
+++ b/core/work/src/main/java/com/practice/work/BlindarWorkManager.kt
@@ -10,10 +10,14 @@ object BlindarWorkManager {
         setPeriodicFetchMealWork(workManager)
     }
 
-    fun setOneTimeFetchDataWork(context: Context) {
+    fun setOneTimeFetchDataWork(
+        context: Context,
+        clearMealDatabase: Boolean = false,
+        clearScheduleDatabase: Boolean = false,
+    ) {
         val workManager = WorkManager.getInstance(context)
-        setOneTimeFetchScheduleWork(workManager)
-        setOneTimeFetchMealWork(workManager)
+        setOneTimeFetchScheduleWork(workManager, clearMealDatabase)
+        setOneTimeFetchMealWork(workManager, clearScheduleDatabase)
     }
 
     fun setUserInfoToRemoteWork(context: Context) {

--- a/feature/main/build.gradle.kts
+++ b/feature/main/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     api(project(":core:designsystem"))
     api(project(":core:combine"))
     api(project(":core:preferences"))
+    implementation(project(":core:work"))
     implementation(project(":core:domain"))
     implementation(project(":core:firebase"))
 

--- a/feature/main/src/main/java/com/practice/main/HorizontalMainScreen.kt
+++ b/feature/main/src/main/java/com/practice/main/HorizontalMainScreen.kt
@@ -39,6 +39,7 @@ fun HorizontalMainScreen(
     onScreenModeChange: (ScreenMode) -> Unit,
     calendarState: CalendarState,
     mealColumns: Int,
+    onRefreshIconClick: () -> Unit,
     onAlarmIconClick: () -> Unit,
     onDateClick: (Date) -> Unit,
     onSwiped: (YearMonth) -> Unit,
@@ -55,8 +56,10 @@ fun HorizontalMainScreen(
     Column(modifier = modifier) {
         MainScreenTopBar(
             schoolName = uiState.selectedSchool.name,
-            onClick = onNavigateToSelectSchoolScreen,
+            onSchoolNameClick = onNavigateToSelectSchoolScreen,
             onClickLabel = stringResource(id = R.string.navigate_to_school_select),
+            isLoading = uiState.isLoading,
+            onRefreshIconClick = onRefreshIconClick,
             iconState = uiState.dailyAlarmIconState,
             onAlarmIconClick = onAlarmIconClick,
             modifier = Modifier
@@ -145,6 +148,7 @@ private fun HorizontalMainScreenPreview() {
             onScreenModeChange = {},
             calendarState = calendarState,
             mealColumns = 3,
+            onRefreshIconClick = {},
             onAlarmIconClick = {},
             onDateClick = {},
             onSwiped = { },

--- a/feature/main/src/main/java/com/practice/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/practice/main/MainScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.practice.designsystem.calendar.core.rememberCalendarState
@@ -57,6 +58,7 @@ fun MainScreen(
     val backgroundModifier = modifier.background(MaterialTheme.colorScheme.surface)
     val mealColumns = if (windowSize.widthSizeClass == WindowWidthSizeClass.Compact) 2 else 3
 
+    val context = LocalContext.current
     Scaffold {
         val paddingModifier = backgroundModifier.padding(it)
         if (windowSize.widthSizeClass == WindowWidthSizeClass.Expanded) {
@@ -66,6 +68,7 @@ fun MainScreen(
                 onScreenModeChange = viewModel::onScreenModeChange,
                 calendarState = calendarState,
                 mealColumns = mealColumns,
+                onRefreshIconClick = { viewModel.onRefreshIconClick(context) },
                 onAlarmIconClick = viewModel::onDailyAlarmIconClick,
                 onDateClick = viewModel::onDateClick,
                 onSwiped = viewModel::onSwiped,
@@ -84,6 +87,7 @@ fun MainScreen(
                 uiState = uiState,
                 calendarState = calendarState,
                 mealColumns = mealColumns,
+                onRefreshIconClick = { viewModel.onRefreshIconClick(context) },
                 onAlarmIconClick = viewModel::onDailyAlarmIconClick,
                 onDateClick = viewModel::onDateClick,
                 onSwiped = viewModel::onSwiped,

--- a/feature/main/src/main/java/com/practice/main/MainScreenViewModel.kt
+++ b/feature/main/src/main/java/com/practice/main/MainScreenViewModel.kt
@@ -1,5 +1,6 @@
 package com.practice.main
 
+import android.content.Context
 import android.os.Build
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
@@ -34,6 +35,7 @@ import com.practice.main.state.toUiSchedule
 import com.practice.preferences.PreferencesRepository
 import com.practice.preferences.ScreenMode
 import com.practice.util.date.DateUtil
+import com.practice.work.BlindarWorkManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
@@ -158,6 +160,14 @@ class MainScreenViewModel @Inject constructor(
                 preferencesRepository.updateDailyAlarmState(nextPreferencesState)
             }
         }
+    }
+
+    fun onRefreshIconClick(context: Context) {
+        BlindarWorkManager.setOneTimeFetchDataWork(
+            context = context,
+            clearMealDatabase = true,
+            clearScheduleDatabase = true,
+        )
     }
 
     private fun getNextDailyAlarmStateAndPreferences(): Boolean? =

--- a/feature/main/src/main/java/com/practice/main/VerticalMainScreen.kt
+++ b/feature/main/src/main/java/com/practice/main/VerticalMainScreen.kt
@@ -43,6 +43,7 @@ fun VerticalMainScreen(
     uiState: MainUiState,
     calendarState: CalendarState,
     mealColumns: Int,
+    onRefreshIconClick: () -> Unit,
     onAlarmIconClick: () -> Unit,
     onDateClick: (Date) -> Unit,
     onSwiped: (YearMonth) -> Unit,
@@ -59,8 +60,10 @@ fun VerticalMainScreen(
     Column(modifier = modifier) {
         MainScreenTopBar(
             schoolName = uiState.selectedSchool.name,
-            onClick = onNavigateToSelectSchoolScreen,
+            onSchoolNameClick = onNavigateToSelectSchoolScreen,
             onClickLabel = stringResource(id = R.string.navigate_to_school_select),
+            isLoading = uiState.isLoading,
+            onRefreshIconClick = onRefreshIconClick,
             iconState = uiState.dailyAlarmIconState,
             onAlarmIconClick = onAlarmIconClick,
             modifier = Modifier
@@ -162,6 +165,7 @@ private fun VerticalMainScreenPreview() {
             uiState = uiState,
             calendarState = calendarState,
             mealColumns = 2,
+            onRefreshIconClick = {},
             onAlarmIconClick = {},
             onDateClick = { selectedDate = it },
             onSwiped = {},

--- a/feature/main/src/main/res/values/strings.xml
+++ b/feature/main/src/main/res/values/strings.xml
@@ -14,6 +14,8 @@
     <string name="main_screen_add_memo">메모 추가하기</string>
     <string name="main_screen_add_memo_description">클릭하여 메모 추가 화면을 엽니다.</string>
 
+    <string name="main_screen_refresh_icon_description">데이터 다시 로드하기</string>
+
     <string name="navigate_to_school_select">학교 선택 화면으로 가기</string>
 
     <string name="open_nutrient_popup_button">영양 정보</string>


### PR DESCRIPTION
# 일반 PR
## 문제 상황

앱에서 데이터가 제대로 보이지 않는 경우, 사용자가 주도적으로 데이터를 다시 가져올 방법이 없었다.

## 해결 방법

메인 화면 TopAppBar에 새로고침 버튼을 추가했다. 새로고침 버튼으로 데이터를 가져오면 식단, 학사일정 DB를 비운 후에 새로 가져온다.

## 수정한 내용

* cb73493e6c5713484e46f4b9d565e8a27ebe5874: 학사일정을 가져오기 전에 학사일정 테이블을 비울 수 있는 기능 추가
* c37f1267ff20eff1bd329c5779ad4cc5adfcde35: 식단을 가져오기 전에 식단 테이블을 비울 수 있는 기능 추가
* a54ecd9d40ee795e9a82eca3621586306d21d9a5: `BlindarWorkManager`에 학사일정, 식단 테이블을 비울 수 있는 매개변수 추가
* 785205569d126722ef32b3d8bcd3cfdafc2fc6b1: `MainViewModel`에 새로고침 버튼 콜백 추가
* 09f80d5f86f4403748193f15f2e13e09076582ee: 메인 화면에 새로고침 아이콘 추가
* 47b0d1676d4664d5a7ea64aae49c411401bdcf32: 새로고침 UI와 콜백 연결