### PR TITLE
feature: 로딩 화면 추가

### DIFF
--- a/app/src/main/java/com/practice/hanbitlunch/BlindarNavHost.kt
+++ b/app/src/main/java/com/practice/hanbitlunch/BlindarNavHost.kt
@@ -130,6 +130,7 @@ fun NavGraphBuilder.blindarMainNavGraph(
                 onAutoLoginFail()
             },
             modifier = Modifier
+                .safeDrawingPadding()
                 .fillMaxSize()
                 .background(MaterialTheme.colorScheme.surface),
         )
@@ -154,6 +155,7 @@ fun NavGraphBuilder.blindarMainNavGraph(
             },
             googleSignInClient = googleSignInClient,
             modifier = Modifier
+                .safeDrawingPadding()
                 .fillMaxSize()
                 .background(MaterialTheme.colorScheme.surface),
         )

--- a/app/src/main/java/com/practice/hanbitlunch/MainActivity.kt
+++ b/app/src/main/java/com/practice/hanbitlunch/MainActivity.kt
@@ -43,7 +43,7 @@ class MainActivity : ComponentActivity() {
                             .fillMaxSize(),
                         googleSignInClient = getGoogleSignInClient(),
                         onNavigateToMainScreen = {
-                            WindowCompat.setDecorFitsSystemWindows(window, true)
+//                            WindowCompat.setDecorFitsSystemWindows(window, true)
                         }
                     )
                 }

--- a/feature/main/src/main/java/com/practice/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/practice/main/MainScreen.kt
@@ -13,9 +13,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
-import com.practice.designsystem.components.TitleLarge
 import com.practice.main.calendar.CalendarMainScreen
 import com.practice.main.daily.DailyMainScreen
+import com.practice.main.loading.LoadingMainScreen
 import com.practice.main.popup.MainScreenModePopup
 import com.practice.main.popup.MemoPopup
 import com.practice.main.popup.NutrientPopup
@@ -48,7 +48,9 @@ fun MainScreen(
         val paddingModifier = backgroundModifier.padding(it)
         when (uiState.mainUiMode) {
             MainUiMode.LOADING -> {
-                TitleLarge(text = "TODO!")
+                LoadingMainScreen(
+                    modifier = paddingModifier,
+                )
             }
 
             MainUiMode.NOT_SET, MainUiMode.CALENDAR -> {

--- a/feature/main/src/main/java/com/practice/main/loading/LoadingMainScreen.kt
+++ b/feature/main/src/main/java/com/practice/main/loading/LoadingMainScreen.kt
@@ -1,0 +1,23 @@
+package com.practice.main.loading
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun LoadingMainScreen(
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier) {
+        CircularProgressIndicator(
+            modifier = Modifier
+                .align(Alignment.Center)
+                .fillMaxSize(0.1f)
+                .aspectRatio(1f, matchHeightConstraintsFirst = true)
+        )
+    }
+}


### PR DESCRIPTION
## 문제 상황

메인 화면에서 데이터를 로딩하는 동안 보여줄 화면이 필요하다.

## 해결 방법

로딩 화면을 구현했다. 간단하게 `CircularLoadingIndicator`로 구현했다.

## 수정한 내용

* 0bfb5070632e959d8c7ce1ebd57de5213858df4b: 로딩 화면 구현
* 2b1b3e5c7b8c2c7753405c1a76b7ce23aa25ff80: 스플래시, 온보딩 화면이 하단 Navigation Rail을 넘어가는 문제가 있어서 두 홤녀에 `Modifier.safeDrawingPadding()`을 적용했다.
