### PR TITLE
feature: 한소네 전용 식단, 일정 팝업 구현

### DIFF
--- a/feature/main/src/main/java/com/practice/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/practice/main/MainScreen.kt
@@ -139,7 +139,9 @@ private fun MainScreenPopups(
                 mealColumns = mealColumns,
                 onNutrientPopupOpen = viewModel::openNutrientPopup,
                 onMealPopupClose = viewModel::onMealPopupClose,
-                modifier = Modifier.padding(popupPadding),
+                modifier = Modifier
+                    .padding(popupPadding)
+                    .widthIn(max = 600.dp),
             )
         }
     }

--- a/feature/main/src/main/java/com/practice/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/practice/main/MainScreen.kt
@@ -17,6 +17,7 @@ import com.practice.main.calendar.CalendarMainScreen
 import com.practice.main.daily.DailyMainScreen
 import com.practice.main.loading.LoadingMainScreen
 import com.practice.main.popup.MainScreenModePopup
+import com.practice.main.popup.MealPopup
 import com.practice.main.popup.MemoPopup
 import com.practice.main.popup.NutrientPopup
 import com.practice.main.popup.popupPadding
@@ -74,7 +75,10 @@ fun MainScreen(
             }
         }
     }
-    MainScreenPopups(viewModel = viewModel)
+    MainScreenPopups(
+        viewModel = viewModel,
+        mealColumns = windowSize.mealColumns,
+    )
 }
 
 val WindowSizeClass.mealColumns: Int
@@ -83,6 +87,7 @@ val WindowSizeClass.mealColumns: Int
 @Composable
 private fun MainScreenPopups(
     viewModel: MainScreenViewModel,
+    mealColumns: Int,
 ) {
     val uiState by viewModel.uiState
 
@@ -120,6 +125,20 @@ private fun MainScreenPopups(
                 modifier = Modifier
                     .padding(popupPadding)
                     .widthIn(max = 600.dp),
+            )
+        }
+    }
+
+    if (uiState.isMealPopupVisible) {
+        MainScreenPopup(onClose = viewModel::onMealPopupClose) {
+            MealPopup(
+                uiMeals = uiState.selectedDateDataState.uiMeals,
+                selectedMealIndex = uiState.selectedMealIndex,
+                onMealTimeClick = viewModel::onMealTimeClick,
+                mealColumns = mealColumns,
+                onNutrientPopupOpen = viewModel::openNutrientPopup,
+                onMealPopupClose = viewModel::onMealPopupClose,
+                modifier = Modifier.padding(popupPadding),
             )
         }
     }

--- a/feature/main/src/main/java/com/practice/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/practice/main/MainScreen.kt
@@ -74,6 +74,17 @@ fun MainScreen(
             }
         }
     }
+    MainScreenPopups(viewModel = viewModel)
+}
+
+val WindowSizeClass.mealColumns: Int
+    get() = if (this.widthSizeClass == WindowWidthSizeClass.Compact) 2 else 3
+
+@Composable
+private fun MainScreenPopups(
+    viewModel: MainScreenViewModel,
+) {
+    val uiState by viewModel.uiState
 
     if (uiState.isNutrientPopupVisible) {
         val selectedMealIndex = uiState.selectedMealIndex
@@ -113,6 +124,3 @@ fun MainScreen(
         }
     }
 }
-
-val WindowSizeClass.mealColumns: Int
-    get() = if (this.widthSizeClass == WindowWidthSizeClass.Compact) 2 else 3

--- a/feature/main/src/main/java/com/practice/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/practice/main/MainScreen.kt
@@ -20,6 +20,7 @@ import com.practice.main.popup.MainScreenModePopup
 import com.practice.main.popup.MealPopup
 import com.practice.main.popup.MemoPopup
 import com.practice.main.popup.NutrientPopup
+import com.practice.main.popup.SchedulePopup
 import com.practice.main.popup.popupPadding
 import com.practice.main.state.MainUiMode
 
@@ -139,6 +140,19 @@ private fun MainScreenPopups(
                 onNutrientPopupOpen = viewModel::openNutrientPopup,
                 onMealPopupClose = viewModel::onMealPopupClose,
                 modifier = Modifier.padding(popupPadding),
+            )
+        }
+    }
+
+    if (uiState.isSchedulePopupVisible) {
+        MainScreenPopup(onClose = viewModel::onSchedulePopupClose) {
+            SchedulePopup(
+                scheduleElements = uiState.selectedDateDataState.memoPopupElements,
+                onMemoPopupOpen = viewModel::openMemoPopup,
+                onSchedulePopupClose = viewModel::onSchedulePopupClose,
+                modifier = Modifier
+                    .padding(popupPadding)
+                    .widthIn(max = 600.dp),
             )
         }
     }

--- a/feature/main/src/main/java/com/practice/main/MainScreenElements.kt
+++ b/feature/main/src/main/java/com/practice/main/MainScreenElements.kt
@@ -639,7 +639,7 @@ private fun MainScreenContentHeaderButtonPreview() {
     }
 }
 
-private val sampleUiMeals = UiMeals(
+internal val sampleUiMeals = UiMeals(
     listOf("조식", "중식", "석식").map {
         UiMeal(2022, 10, 28, it, previewMenus, previewNutrients)
     }

--- a/feature/main/src/main/java/com/practice/main/MainScreenViewModel.kt
+++ b/feature/main/src/main/java/com/practice/main/MainScreenViewModel.kt
@@ -298,6 +298,14 @@ class MainScreenViewModel @Inject constructor(
         }
     }
 
+    fun onMealPopupOpen() {
+        updateUiState(isMealPopupVisible = true)
+    }
+
+    fun onMealPopupClose() {
+        updateUiState(isMealPopupVisible = false)
+    }
+
     suspend fun sendFeedback(appVersionName: String, contents: String) {
         /**
          * userId: BlindarFirebase에서 얻으면 됨

--- a/feature/main/src/main/java/com/practice/main/MainScreenViewModel.kt
+++ b/feature/main/src/main/java/com/practice/main/MainScreenViewModel.kt
@@ -108,6 +108,7 @@ class MainScreenViewModel @Inject constructor(
         selectedSchool: School = state.selectedSchool,
         isNutrientPopupVisible: Boolean = state.isNutrientPopupVisible,
         isMemoPopupVisible: Boolean = state.isMemoPopupVisible,
+        isMealPopupVisible: Boolean = state.isMealPopupVisible,
         mainUiMode: MainUiMode = state.mainUiMode
     ) {
         val isCollectNeeded =
@@ -124,6 +125,7 @@ class MainScreenViewModel @Inject constructor(
                 selectedSchool = selectedSchool,
                 isNutrientPopupVisible = isNutrientPopupVisible,
                 isMemoPopupVisible = isMemoPopupVisible,
+                isMealPopupVisible = isMealPopupVisible,
                 mainUiMode = mainUiMode,
             )
         }

--- a/feature/main/src/main/java/com/practice/main/MainScreenViewModel.kt
+++ b/feature/main/src/main/java/com/practice/main/MainScreenViewModel.kt
@@ -109,6 +109,7 @@ class MainScreenViewModel @Inject constructor(
         isNutrientPopupVisible: Boolean = state.isNutrientPopupVisible,
         isMemoPopupVisible: Boolean = state.isMemoPopupVisible,
         isMealPopupVisible: Boolean = state.isMealPopupVisible,
+        isSchedulePopupVisible: Boolean = state.isSchedulePopupVisible,
         mainUiMode: MainUiMode = state.mainUiMode
     ) {
         val isCollectNeeded =
@@ -126,6 +127,7 @@ class MainScreenViewModel @Inject constructor(
                 isNutrientPopupVisible = isNutrientPopupVisible,
                 isMemoPopupVisible = isMemoPopupVisible,
                 isMealPopupVisible = isMealPopupVisible,
+                isSchedulePopupVisible = isSchedulePopupVisible,
                 mainUiMode = mainUiMode,
             )
         }
@@ -304,6 +306,14 @@ class MainScreenViewModel @Inject constructor(
 
     fun onMealPopupClose() {
         updateUiState(isMealPopupVisible = false)
+    }
+
+    fun onSchedulePopupOpen() {
+        updateUiState(isSchedulePopupVisible = true)
+    }
+
+    fun onSchedulePopupClose() {
+        updateUiState(isSchedulePopupVisible = false)
     }
 
     suspend fun sendFeedback(appVersionName: String, contents: String) {

--- a/feature/main/src/main/java/com/practice/main/PreviewUtils.kt
+++ b/feature/main/src/main/java/com/practice/main/PreviewUtils.kt
@@ -42,6 +42,7 @@ internal fun previewMainUiState(): MainUiState {
         ),
         isNutrientPopupVisible = false,
         isMemoPopupVisible = false,
+        isMealPopupVisible = false,
         mainUiMode = MainUiMode.CALENDAR,
     )
 }

--- a/feature/main/src/main/java/com/practice/main/PreviewUtils.kt
+++ b/feature/main/src/main/java/com/practice/main/PreviewUtils.kt
@@ -43,6 +43,7 @@ internal fun previewMainUiState(): MainUiState {
         isNutrientPopupVisible = false,
         isMemoPopupVisible = false,
         isMealPopupVisible = false,
+        isSchedulePopupVisible = false,
         mainUiMode = MainUiMode.CALENDAR,
     )
 }

--- a/feature/main/src/main/java/com/practice/main/calendar/VerticalCalendarMainScreen.kt
+++ b/feature/main/src/main/java/com/practice/main/calendar/VerticalCalendarMainScreen.kt
@@ -160,6 +160,7 @@ private fun VerticalCalendarMainScreenPreview() {
                 isNutrientPopupVisible = false,
                 isMemoPopupVisible = false,
                 isMealPopupVisible = false,
+                isSchedulePopupVisible = false,
                 mainUiMode = MainUiMode.CALENDAR,
             )
         )

--- a/feature/main/src/main/java/com/practice/main/calendar/VerticalCalendarMainScreen.kt
+++ b/feature/main/src/main/java/com/practice/main/calendar/VerticalCalendarMainScreen.kt
@@ -159,6 +159,7 @@ private fun VerticalCalendarMainScreenPreview() {
                 ),
                 isNutrientPopupVisible = false,
                 isMemoPopupVisible = false,
+                isMealPopupVisible = false,
                 mainUiMode = MainUiMode.CALENDAR,
             )
         )

--- a/feature/main/src/main/java/com/practice/main/daily/DailyMainScreen.kt
+++ b/feature/main/src/main/java/com/practice/main/daily/DailyMainScreen.kt
@@ -43,7 +43,7 @@ fun DailyMainScreen(
                 onNutrientPopupOpen = viewModel::openNutrientPopup,
                 onMemoPopupOpen = viewModel::openMemoPopup,
                 onMealPopupOpen = viewModel::onMealPopupOpen,
-                onSchedulePopupOpen = {/* TODO */ },
+                onSchedulePopupOpen = viewModel::onSchedulePopupOpen,
                 modifier = modifier,
             )
         }
@@ -60,7 +60,7 @@ fun DailyMainScreen(
                 onNutrientPopupOpen = viewModel::openNutrientPopup,
                 onMemoPopupOpen = viewModel::openMemoPopup,
                 onMealPopupOpen = viewModel::onMealPopupOpen,
-                onSchedulePopupOpen = {/* TODO */ },
+                onSchedulePopupOpen = viewModel::onSchedulePopupOpen,
                 modifier = modifier,
             )
         }

--- a/feature/main/src/main/java/com/practice/main/daily/DailyMainScreen.kt
+++ b/feature/main/src/main/java/com/practice/main/daily/DailyMainScreen.kt
@@ -42,6 +42,8 @@ fun DailyMainScreen(
                 onMealTimeClick = viewModel::onMealTimeClick,
                 onNutrientPopupOpen = viewModel::openNutrientPopup,
                 onMemoPopupOpen = viewModel::openMemoPopup,
+                onMealPopupOpen = viewModel::onMealPopupOpen,
+                onSchedulePopupOpen = {/* TODO */ },
                 modifier = modifier,
             )
         }
@@ -57,6 +59,8 @@ fun DailyMainScreen(
                 onMealTimeClick = viewModel::onMealTimeClick,
                 onNutrientPopupOpen = viewModel::openNutrientPopup,
                 onMemoPopupOpen = viewModel::openMemoPopup,
+                onMealPopupOpen = viewModel::onMealPopupOpen,
+                onSchedulePopupOpen = {/* TODO */ },
                 modifier = modifier,
             )
         }

--- a/feature/main/src/main/java/com/practice/main/daily/HorizontalDailyMainScreen.kt
+++ b/feature/main/src/main/java/com/practice/main/daily/HorizontalDailyMainScreen.kt
@@ -135,7 +135,7 @@ private fun DatePickerCard(
     ) {
         LazyColumn(
             modifier = Modifier.fillMaxHeight(),
-            contentPadding = PaddingValues(16.dp),
+            contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             item {

--- a/feature/main/src/main/java/com/practice/main/daily/HorizontalDailyMainScreen.kt
+++ b/feature/main/src/main/java/com/practice/main/daily/HorizontalDailyMainScreen.kt
@@ -25,6 +25,7 @@ import com.practice.main.MainScreenContents
 import com.practice.main.MainScreenTopBar
 import com.practice.main.R
 import com.practice.main.daily.components.DateQuickNavigationButtons
+import com.practice.main.daily.components.ScreenModeOpenPopupButtons
 import com.practice.main.daily.picker.DailyDatePicker
 import com.practice.main.daily.picker.DailyDatePickerState
 import com.practice.main.daily.picker.rememberDailyDatePickerState
@@ -52,6 +53,8 @@ fun HorizontalDailyMainScreen(
     onMealTimeClick: (Int) -> Unit,
     onNutrientPopupOpen: () -> Unit,
     onMemoPopupOpen: () -> Unit,
+    onMealPopupOpen: () -> Unit,
+    onSchedulePopupOpen: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier) {
@@ -72,7 +75,9 @@ fun HorizontalDailyMainScreen(
             mealColumns = mealColumns,
             onMealTimeClick = onMealTimeClick,
             onNutrientPopupOpen = onNutrientPopupOpen,
-            onMemoPopupOpen = onMemoPopupOpen
+            onMemoPopupOpen = onMemoPopupOpen,
+            onMealPopupOpen = onMealPopupOpen,
+            onSchedulePopupOpen = onSchedulePopupOpen,
         )
     }
 }
@@ -84,7 +89,9 @@ private fun HorizontalDailyMainScreenContents(
     mealColumns: Int,
     onMealTimeClick: (Int) -> Unit,
     onNutrientPopupOpen: () -> Unit,
-    onMemoPopupOpen: () -> Unit
+    onMemoPopupOpen: () -> Unit,
+    onMealPopupOpen: () -> Unit,
+    onSchedulePopupOpen: () -> Unit,
 ) {
     Row(
         modifier = Modifier.padding(16.dp),
@@ -95,7 +102,12 @@ private fun HorizontalDailyMainScreenContents(
             modifier = Modifier
                 .weight(1f)
                 .fillMaxHeight()
-        )
+        ) {
+            ScreenModeOpenPopupButtons(
+                onMealPopupOpen = onMealPopupOpen,
+                onSchedulePopupOpen = onSchedulePopupOpen,
+            )
+        }
         MainScreenContents(
             uiMeals = uiState.selectedDateDataState.uiMeals,
             memoPopupElements = uiState.selectedDateDataState.memoPopupElements,
@@ -113,6 +125,7 @@ private fun HorizontalDailyMainScreenContents(
 private fun DatePickerCard(
     datePickerState: DailyDatePickerState,
     modifier: Modifier = Modifier,
+    trailingContents: @Composable (() -> Unit)? = null,
 ) {
     ElevatedCard(
         modifier = modifier,
@@ -133,6 +146,11 @@ private fun DatePickerCard(
                     datePickerState = datePickerState,
                     modifier = Modifier.fillMaxWidth(),
                 )
+            }
+            trailingContents?.let {
+                item {
+                    trailingContents()
+                }
             }
         }
     }
@@ -189,6 +207,8 @@ private fun HorizontalDailyMainScreenPreview() {
             onMealTimeClick = {},
             onNutrientPopupOpen = {},
             onMemoPopupOpen = {},
+            onMealPopupOpen = {},
+            onSchedulePopupOpen = {},
             modifier = Modifier
                 .fillMaxWidth()
                 .background(MaterialTheme.colorScheme.surface),

--- a/feature/main/src/main/java/com/practice/main/daily/HorizontalDailyMainScreen.kt
+++ b/feature/main/src/main/java/com/practice/main/daily/HorizontalDailyMainScreen.kt
@@ -189,6 +189,7 @@ private fun HorizontalDailyMainScreenPreview() {
         isNutrientPopupVisible = false,
         isMemoPopupVisible = false,
         isMealPopupVisible = false,
+        isSchedulePopupVisible = false,
         mainUiMode = MainUiMode.DAILY,
     )
     val datePickerState = rememberDailyDatePickerState(

--- a/feature/main/src/main/java/com/practice/main/daily/HorizontalDailyMainScreen.kt
+++ b/feature/main/src/main/java/com/practice/main/daily/HorizontalDailyMainScreen.kt
@@ -104,7 +104,9 @@ private fun HorizontalDailyMainScreenContents(
                 .fillMaxHeight()
         ) {
             ScreenModeOpenPopupButtons(
+                isMealPopupEnabled = uiState.isMealExists,
                 onMealPopupOpen = onMealPopupOpen,
+                isSchedulePopupEnabled = uiState.isScheduleOrMemoExists,
                 onSchedulePopupOpen = onSchedulePopupOpen,
             )
         }

--- a/feature/main/src/main/java/com/practice/main/daily/HorizontalDailyMainScreen.kt
+++ b/feature/main/src/main/java/com/practice/main/daily/HorizontalDailyMainScreen.kt
@@ -170,6 +170,7 @@ private fun HorizontalDailyMainScreenPreview() {
         ),
         isNutrientPopupVisible = false,
         isMemoPopupVisible = false,
+        isMealPopupVisible = false,
         mainUiMode = MainUiMode.DAILY,
     )
     val datePickerState = rememberDailyDatePickerState(

--- a/feature/main/src/main/java/com/practice/main/daily/VerticalDailyMainScreen.kt
+++ b/feature/main/src/main/java/com/practice/main/daily/VerticalDailyMainScreen.kt
@@ -110,7 +110,9 @@ private fun VerticalDailyMainScreenContents(
             header = {
                 DatePickerCard(datePickerState = datePickerState) {
                     ScreenModeOpenPopupButtons(
+                        isMealPopupEnabled = uiState.isMealExists,
                         onMealPopupOpen = onMealPopupOpen,
+                        isSchedulePopupEnabled = uiState.isScheduleOrMemoExists,
                         onSchedulePopupOpen = onSchedulePopupOpen,
                     )
                 }
@@ -178,6 +180,7 @@ private fun VerticalDailyMainScreenPreview() {
         isNutrientPopupVisible = false,
         isMemoPopupVisible = false,
         isMealPopupVisible = false,
+        isSchedulePopupVisible = false,
         mainUiMode = MainUiMode.DAILY,
     )
     val datePickerState = rememberDailyDatePickerState(

--- a/feature/main/src/main/java/com/practice/main/daily/VerticalDailyMainScreen.kt
+++ b/feature/main/src/main/java/com/practice/main/daily/VerticalDailyMainScreen.kt
@@ -92,7 +92,7 @@ private fun VerticalDailyMainScreenContents(
     onSchedulePopupOpen: () -> Unit,
 ) {
     Column(
-        modifier = Modifier.padding(16.dp),
+        modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         MainScreenContents(

--- a/feature/main/src/main/java/com/practice/main/daily/VerticalDailyMainScreen.kt
+++ b/feature/main/src/main/java/com/practice/main/daily/VerticalDailyMainScreen.kt
@@ -165,6 +165,7 @@ private fun VerticalDailyMainScreenPreview() {
         ),
         isNutrientPopupVisible = false,
         isMemoPopupVisible = false,
+        isMealPopupVisible = false,
         mainUiMode = MainUiMode.DAILY,
     )
     val datePickerState = rememberDailyDatePickerState(

--- a/feature/main/src/main/java/com/practice/main/daily/VerticalDailyMainScreen.kt
+++ b/feature/main/src/main/java/com/practice/main/daily/VerticalDailyMainScreen.kt
@@ -22,6 +22,7 @@ import com.practice.main.MainScreenTopBar
 import com.practice.main.R
 import com.practice.main.daily.components.DateQuickNavigation
 import com.practice.main.daily.components.DateQuickNavigationButtons
+import com.practice.main.daily.components.ScreenModeOpenPopupButtons
 import com.practice.main.daily.picker.DailyDatePicker
 import com.practice.main.daily.picker.DailyDatePickerState
 import com.practice.main.daily.picker.rememberDailyDatePickerState
@@ -50,6 +51,8 @@ fun VerticalDailyMainScreen(
     onMealTimeClick: (Int) -> Unit,
     onNutrientPopupOpen: () -> Unit,
     onMemoPopupOpen: () -> Unit,
+    onMealPopupOpen: () -> Unit,
+    onSchedulePopupOpen: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier) {
@@ -70,7 +73,9 @@ fun VerticalDailyMainScreen(
             mealColumns = mealColumns,
             onMealTimeClick = onMealTimeClick,
             onNutrientPopupOpen = onNutrientPopupOpen,
-            onMemoPopupOpen = onMemoPopupOpen
+            onMemoPopupOpen = onMemoPopupOpen,
+            onMealPopupOpen = onMealPopupOpen,
+            onSchedulePopupOpen = onSchedulePopupOpen,
         )
     }
 }
@@ -83,6 +88,8 @@ private fun VerticalDailyMainScreenContents(
     onMealTimeClick: (Int) -> Unit,
     onNutrientPopupOpen: () -> Unit,
     onMemoPopupOpen: () -> Unit,
+    onMealPopupOpen: () -> Unit,
+    onSchedulePopupOpen: () -> Unit,
 ) {
     Column(
         modifier = Modifier.padding(16.dp),
@@ -101,9 +108,12 @@ private fun VerticalDailyMainScreenContents(
                 .fillMaxWidth(),
             emptyContentAlignment = Alignment.TopCenter,
             header = {
-                DatePickerCard(
-                    datePickerState = datePickerState,
-                )
+                DatePickerCard(datePickerState = datePickerState) {
+                    ScreenModeOpenPopupButtons(
+                        onMealPopupOpen = onMealPopupOpen,
+                        onSchedulePopupOpen = onSchedulePopupOpen,
+                    )
+                }
             }
         )
     }
@@ -113,6 +123,7 @@ private fun VerticalDailyMainScreenContents(
 private fun DatePickerCard(
     datePickerState: DailyDatePickerState,
     modifier: Modifier = Modifier,
+    trailingContents: @Composable (() -> Unit)? = null,
 ) {
     ElevatedCard(
         modifier = modifier,
@@ -129,6 +140,7 @@ private fun DatePickerCard(
                     it.daysToMove.absoluteValue <= 1
                 }
             )
+            trailingContents?.invoke()
         }
     }
 }
@@ -184,6 +196,8 @@ private fun VerticalDailyMainScreenPreview() {
             onMealTimeClick = {},
             onNutrientPopupOpen = {},
             onMemoPopupOpen = {},
+            onMealPopupOpen = {},
+            onSchedulePopupOpen = {},
             modifier = Modifier
                 .fillMaxWidth()
                 .background(MaterialTheme.colorScheme.surface),

--- a/feature/main/src/main/java/com/practice/main/daily/components/DailyModeElements.kt
+++ b/feature/main/src/main/java/com/practice/main/daily/components/DailyModeElements.kt
@@ -2,12 +2,15 @@ package com.practice.main.daily.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
 import androidx.compose.material3.DatePickerFormatter
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -17,14 +20,17 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.practice.designsystem.LightAndDarkPreview
 import com.practice.designsystem.components.BodySmall
 import com.practice.designsystem.theme.BlindarTheme
+import com.practice.main.R
 import com.practice.main.daily.picker.DailyDatePickerState
 import com.practice.main.daily.picker.rememberDailyDatePickerState
 import kotlin.math.absoluteValue
@@ -80,6 +86,44 @@ internal fun DateQuickNavigationButton(
             modifier = Modifier.align(Alignment.Center),
             textColor = contentColorFor(backgroundColor = backgroundColor),
         )
+    }
+}
+
+@Composable
+internal fun ScreenModeOpenPopupButtons(
+    onMealPopupOpen: () -> Unit,
+    onSchedulePopupOpen: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(modifier = modifier) {
+        ScreenModeOpenPopupButton(
+            description = stringResource(id = R.string.open_meal_popup),
+            onOpenPopup = onMealPopupOpen,
+        )
+        ScreenModeOpenPopupButton(
+            description = stringResource(id = R.string.open_schedule_popup),
+            onOpenPopup = onSchedulePopupOpen,
+        )
+    }
+}
+
+@Composable
+private fun ScreenModeOpenPopupButton(
+    description: String,
+    onOpenPopup: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Button(
+        onClick = onOpenPopup,
+        modifier = modifier
+            .semantics {
+                contentDescription = description
+            }
+            .size(0.dp)
+            .background(Color.Transparent),
+        interactionSource = MutableInteractionSource()
+    ) {
+
     }
 }
 

--- a/feature/main/src/main/java/com/practice/main/daily/components/DailyModeElements.kt
+++ b/feature/main/src/main/java/com/practice/main/daily/components/DailyModeElements.kt
@@ -2,7 +2,6 @@ package com.practice.main.daily.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -10,7 +9,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
 import androidx.compose.material3.DatePickerFormatter
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -91,17 +89,21 @@ internal fun DateQuickNavigationButton(
 
 @Composable
 internal fun ScreenModeOpenPopupButtons(
+    isMealPopupEnabled: Boolean,
     onMealPopupOpen: () -> Unit,
+    isSchedulePopupEnabled: Boolean,
     onSchedulePopupOpen: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Row(modifier = modifier) {
         ScreenModeOpenPopupButton(
-            description = stringResource(id = R.string.open_meal_popup),
+            enabled = isMealPopupEnabled,
+            description = stringResource(id = if (isMealPopupEnabled) R.string.open_meal_popup else R.string.meal_popup_unavailable),
             onOpenPopup = onMealPopupOpen,
         )
         ScreenModeOpenPopupButton(
-            description = stringResource(id = R.string.open_schedule_popup),
+            enabled = isSchedulePopupEnabled,
+            description = stringResource(id = if (isSchedulePopupEnabled) R.string.open_schedule_popup else R.string.schedule_popup_unavailable),
             onOpenPopup = onSchedulePopupOpen,
         )
     }
@@ -109,22 +111,20 @@ internal fun ScreenModeOpenPopupButtons(
 
 @Composable
 private fun ScreenModeOpenPopupButton(
+    enabled: Boolean,
     description: String,
     onOpenPopup: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Button(
-        onClick = onOpenPopup,
+    Box(
         modifier = modifier
             .semantics {
                 contentDescription = description
             }
-            .size(0.dp)
+            .clickable(enabled = enabled, onClick = onOpenPopup)
+            .size(8.dp)
             .background(Color.Transparent),
-        interactionSource = MutableInteractionSource()
-    ) {
-
-    }
+    )
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/feature/main/src/main/java/com/practice/main/daily/components/DailyModeElements.kt
+++ b/feature/main/src/main/java/com/practice/main/daily/components/DailyModeElements.kt
@@ -119,6 +119,7 @@ private fun ScreenModeOpenPopupButton(
     Box(
         modifier = modifier
             .semantics {
+                role = Role.Button
                 contentDescription = description
             }
             .clickable(enabled = enabled, onClick = onOpenPopup)

--- a/feature/main/src/main/java/com/practice/main/popup/MealPopup.kt
+++ b/feature/main/src/main/java/com/practice/main/popup/MealPopup.kt
@@ -1,0 +1,98 @@
+package com.practice.main.popup
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.contentColorFor
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.practice.designsystem.LightAndDarkPreview
+import com.practice.designsystem.components.BodyLarge
+import com.practice.designsystem.theme.BlindarTheme
+import com.practice.main.MealContent
+import com.practice.main.R
+import com.practice.main.sampleUiMeals
+import com.practice.main.state.UiMeals
+
+@Composable
+fun MealPopup(
+    uiMeals: UiMeals,
+    selectedMealIndex: Int,
+    onMealTimeClick: (Int) -> Unit,
+    mealColumns: Int,
+    onNutrientPopupOpen: () -> Unit,
+    onMealPopupClose: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.background(MaterialTheme.colorScheme.surface),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        MealContent(
+            uiMeals = uiMeals,
+            selectedIndex = selectedMealIndex,
+            onMealTimeClick = onMealTimeClick,
+            columns = mealColumns,
+            onNutrientPopupOpen = onNutrientPopupOpen,
+        )
+        CloseMealPopupButton(
+            onClose = onMealPopupClose,
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(8.dp)),
+        )
+    }
+}
+
+@Composable
+private fun CloseMealPopupButton(
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val background = MaterialTheme.colorScheme.primaryContainer
+    val textColor = contentColorFor(backgroundColor = background)
+    Box(
+        modifier = modifier
+            .clickable { onClose() }
+            .background(background),
+    ) {
+        BodyLarge(
+            text = stringResource(id = R.string.meal_popup_close),
+            textColor = textColor,
+            modifier = Modifier
+                .padding(vertical = 16.dp)
+                .align(Alignment.Center),
+        )
+    }
+}
+
+@LightAndDarkPreview
+@Composable
+private fun MealPopupPreview() {
+    var selectedMealIndex by remember { mutableIntStateOf(0) }
+    BlindarTheme {
+        MealPopup(
+            uiMeals = sampleUiMeals,
+            selectedMealIndex = selectedMealIndex,
+            onMealTimeClick = { selectedMealIndex = it },
+            mealColumns = 2,
+            onNutrientPopupOpen = {},
+            onMealPopupClose = {},
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+}

--- a/feature/main/src/main/java/com/practice/main/popup/SchedulePopup.kt
+++ b/feature/main/src/main/java/com/practice/main/popup/SchedulePopup.kt
@@ -1,0 +1,99 @@
+package com.practice.main.popup
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.contentColorFor
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.hsk.ktx.date.Date
+import com.practice.designsystem.LightAndDarkPreview
+import com.practice.designsystem.components.BodyLarge
+import com.practice.designsystem.theme.BlindarTheme
+import com.practice.main.R
+import com.practice.main.ScheduleContent
+import com.practice.main.previewMemos
+import com.practice.main.previewSchedules
+import com.practice.main.state.MemoPopupElement
+import com.practice.main.state.UiMemos
+import com.practice.main.state.UiSchedules
+import com.practice.main.state.mergeSchedulesAndMemos
+import kotlinx.collections.immutable.ImmutableList
+
+@Composable
+fun SchedulePopup(
+    scheduleElements: ImmutableList<MemoPopupElement>,
+    onMemoPopupOpen: () -> Unit,
+    onSchedulePopupClose: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.background(MaterialTheme.colorScheme.surface),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        ScheduleContent(
+            scheduleElements = scheduleElements,
+            onMemoPopupOpen = onMemoPopupOpen,
+        )
+        CloseSchedulePopupButton(
+            onClose = onSchedulePopupClose,
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(8.dp))
+        )
+    }
+}
+
+@Composable
+private fun CloseSchedulePopupButton(
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val background = MaterialTheme.colorScheme.primaryContainer
+    val textColor = contentColorFor(backgroundColor = background)
+    Box(
+        modifier = modifier
+            .clickable { onClose() }
+            .background(background),
+    ) {
+        BodyLarge(
+            text = stringResource(id = R.string.schedule_popup_close),
+            textColor = textColor,
+            modifier = Modifier
+                .padding(vertical = 16.dp)
+                .align(Alignment.Center),
+        )
+    }
+}
+
+@LightAndDarkPreview
+@Composable
+private fun SchedulePopupPreview() {
+    BlindarTheme {
+        SchedulePopup(
+            scheduleElements = mergeSchedulesAndMemos(
+                UiSchedules(
+                    date = Date.now(),
+                    uiSchedules = previewSchedules,
+                ),
+                UiMemos(
+                    date = Date.now(),
+                    memos = previewMemos,
+                ),
+            ),
+            onMemoPopupOpen = {},
+            onSchedulePopupClose = {},
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+}

--- a/feature/main/src/main/java/com/practice/main/state/MainUiState.kt
+++ b/feature/main/src/main/java/com/practice/main/state/MainUiState.kt
@@ -29,6 +29,12 @@ data class MainUiState(
         get() = monthlyDataState.firstOrNull { it.date == selectedDate }
             ?: DailyData.Empty
 
+    val isMealExists: Boolean
+        get() = !selectedDateDataState.uiMeals.isEmpty
+
+    val isScheduleOrMemoExists: Boolean
+        get()=selectedDateDataState.memoPopupElements.isNotEmpty()
+
     fun updateMemoUiState(date: Date, uiMemos: UiMemos): List<DailyData> {
         return if (monthlyDataState.any { it.date == date }) {
             addMemoUiStateOnExistingDate(date, uiMemos)

--- a/feature/main/src/main/java/com/practice/main/state/MainUiState.kt
+++ b/feature/main/src/main/java/com/practice/main/state/MainUiState.kt
@@ -15,6 +15,7 @@ data class MainUiState(
     val selectedSchool: School,
     val isNutrientPopupVisible: Boolean,
     val isMemoPopupVisible: Boolean,
+    val isMealPopupVisible: Boolean,
     val mainUiMode: MainUiMode,
 ) {
     val yearMonth: YearMonth
@@ -73,6 +74,7 @@ data class MainUiState(
             selectedSchool = School.EmptySchool,
             isNutrientPopupVisible = false,
             isMemoPopupVisible = false,
+            isMealPopupVisible = false,
             mainUiMode = MainUiMode.LOADING,
         )
     }

--- a/feature/main/src/main/java/com/practice/main/state/MainUiState.kt
+++ b/feature/main/src/main/java/com/practice/main/state/MainUiState.kt
@@ -16,6 +16,7 @@ data class MainUiState(
     val isNutrientPopupVisible: Boolean,
     val isMemoPopupVisible: Boolean,
     val isMealPopupVisible: Boolean,
+    val isSchedulePopupVisible: Boolean,
     val mainUiMode: MainUiMode,
 ) {
     val yearMonth: YearMonth
@@ -75,6 +76,7 @@ data class MainUiState(
             isNutrientPopupVisible = false,
             isMemoPopupVisible = false,
             isMealPopupVisible = false,
+            isSchedulePopupVisible = false,
             mainUiMode = MainUiMode.LOADING,
         )
     }

--- a/feature/main/src/main/res/values/strings.xml
+++ b/feature/main/src/main/res/values/strings.xml
@@ -27,6 +27,9 @@
     <string name="quick_navigation_plus_1_description">내일 데이터 보기</string>
     <string name="quick_navigation_plus_7_description">일주일 후 데이터 보기</string>
 
+    <string name="open_meal_popup">식단 빠르게 보기</string>
+    <string name="open_schedule_popup">일정 팝업으로 빠르게 보기</string>
+
     <string name="button_selected">선택됨</string>
     <string name="button_not_selected">선택되지 않음</string>
 

--- a/feature/main/src/main/res/values/strings.xml
+++ b/feature/main/src/main/res/values/strings.xml
@@ -29,7 +29,7 @@
 
     <string name="open_meal_popup">식단 빠르게 보기</string>
     <string name="meal_popup_unavailable">식단이 없습니다.</string>
-    <string name="open_schedule_popup">일정 팝업으로 빠르게 보기</string>
+    <string name="open_schedule_popup">일정 빠르게 보기</string>
     <string name="schedule_popup_unavailable">일정이 없습니다.</string>
 
     <string name="button_selected">선택됨</string>

--- a/feature/main/src/main/res/values/strings.xml
+++ b/feature/main/src/main/res/values/strings.xml
@@ -61,6 +61,8 @@
     <string name="ui_mode_popup_calendar_mode_set">달력으로 보기 모드를 사용합니다.</string>
     <string name="ui_mode_popup_daily_mode_set">하루씩 보기 모드를 사용합니다.</string>
 
+    <string name="meal_popup_close">닫기</string>
+
     <string name="feedback_popup_title">피드백 보내기</string>
     <string name="feedback_popup_textfield_placeholder">블린더 사용 후기를 알려주세요!</string>
     <string name="feedback_popup_textfield_error_empty">피드백을 입력해 주세요.</string>

--- a/feature/main/src/main/res/values/strings.xml
+++ b/feature/main/src/main/res/values/strings.xml
@@ -28,7 +28,9 @@
     <string name="quick_navigation_plus_7_description">일주일 후 데이터 보기</string>
 
     <string name="open_meal_popup">식단 빠르게 보기</string>
+    <string name="meal_popup_unavailable">식단이 없습니다.</string>
     <string name="open_schedule_popup">일정 팝업으로 빠르게 보기</string>
+    <string name="schedule_popup_unavailable">일정이 없습니다.</string>
 
     <string name="button_selected">선택됨</string>
     <string name="button_not_selected">선택되지 않음</string>
@@ -65,6 +67,8 @@
     <string name="ui_mode_popup_daily_mode_set">하루씩 보기 모드를 사용합니다.</string>
 
     <string name="meal_popup_close">닫기</string>
+
+    <string name="schedule_popup_close">닫기</string>
 
     <string name="feedback_popup_title">피드백 보내기</string>
     <string name="feedback_popup_textfield_placeholder">블린더 사용 후기를 알려주세요!</string>


### PR DESCRIPTION
## 문제 상황

날짜 입력 후 식단, 일정으로 가기 위해 스와이프를 너무 많이 해야 한다는 피드백이 있었다. 식단 또는 일정을 빠르게 볼 수 있는 방법이 필요하다.

## 해결 방법

크기가 매우 작아 (사실상) TalkBack으로만 클릭할 수 있는 투명 버튼을 추가하였다. 투명 버튼을 클릭하면 식단 또는 일정 팝업이 보이게 된다.

![image](https://github.com/blinder-23/blindar-android/assets/45386920/5e5f2158-3536-48cc-beab-f67af26d49aa)

![image](https://github.com/blinder-23/blindar-android/assets/45386920/d2fed81e-b87d-4bc2-a529-e3f316103114)

![image](https://github.com/blinder-23/blindar-android/assets/45386920/70a9a527-f113-4190-a26e-2d192290396e)


## 수정한 내용

* 4dp*4dp짜리 투명 버튼 추가
* 식단, 일정 팝업 추가
* 투명 버튼을 `하루씩 보기 모드`의 DatePicker 바로 밑에 추가
* 버튼을 클릭했을 때 식단 또는 일정 팝업이 보이도록 수정