### PR TITLE
change: 메모 팝업 닫기 버튼의 텍스트를 '닫기'에서 '확인'으로 수정

### DIFF
--- a/feature/main/src/main/res/values/strings.xml
+++ b/feature/main/src/main/res/values/strings.xml
@@ -57,7 +57,7 @@
     <string name="memo_popup_item_label">일정 입력</string>
     <string name="memo_popup_clear_text">%s 내용 지우기</string>
     <string name="memo_popup_item_delete">%s 삭제하기</string>
-    <string name="memo_popup_close">닫기</string>
+    <string name="memo_popup_close">확인</string>
 
     <string name="ui_mode_popup_title">하루씩 보기 모드를 켤까요?</string>
     <string name="ui_mode_popup_body">스크린 리더에 최적화된 하루씩 보기 모드를 사용해 보세요. 달력 대신 날짜를 직접 입력하여 정보를 볼 수 있습니다.\n\n화면 모드는 설정 화면에서도 바꿀 수 있습니다.</string>


### PR DESCRIPTION
## 문제 상황

피드백 중 메모 팝업의 `닫기` 버튼의 이름이 헷갈린다는 의견이 있었다. 명시적으로 저장 버튼이 없기 때문에, `닫기`를 눌러도 메모가 저장되는 것인지 명확하지 않다는 의견.

## 해결 방법

따라서 `저장` 또는 `확인` 등 다른 이름을 사용하는 것이 좋다. 여러 후보 중 이번에는 `확인` 문구를 사용하기로 결정했다.

## 수정한 내용

* 메모 팝업에서 `닫기` 버튼을 `확인`으로 수정
