### PR TITLE
change: 내용 지우기, 삭제하기 버튼의 description을 수정

### DIFF
--- a/feature/main/src/main/res/values/strings.xml
+++ b/feature/main/src/main/res/values/strings.xml
@@ -55,8 +55,8 @@
     <string name="memo_popup_title">%d월 %d일 메모 편집</string>
     <string name="memo_popup_add_memo">+ 메모 추가하기</string>
     <string name="memo_popup_item_label">일정 입력</string>
-    <string name="memo_popup_clear_text">%s 내용 지우기</string>
-    <string name="memo_popup_item_delete">%s 삭제하기</string>
+    <string name="memo_popup_clear_text">내용 지우기 %s</string>
+    <string name="memo_popup_item_delete">삭제하기 %s</string>
     <string name="memo_popup_close">확인</string>
 
     <string name="ui_mode_popup_title">하루씩 보기 모드를 켤까요?</string>


### PR DESCRIPTION
## 문제 상황

메모 팝업에서, `{내용} 내용 지우기`와 `{내용} 삭제` 버튼의 텍스트가 헷갈린다는 피드백이 있었다. 왜 메모를 2번 읽어주지? 라고 생각할 수도 있다는 것이다.

## 해결 방법

버튼 이름을 먼저 읽어주도록 수정했다. 즉, 다음과 같다.

* `내용 지우기 {내용}`
* `삭제 {내용}`

일반적으로 버튼의 역할을 간단하게 요약한 후, 자세한 설명을 덧붙이는 방식이 좋다고 한다.

## 수정한 내용

커밋 참고
