### PR TITLE
feature: 메모 추가 기능을 더 자세히 설명

### DIFF
--- a/feature/main/src/main/java/com/practice/main/popup/MemoPopup.kt
+++ b/feature/main/src/main/java/com/practice/main/popup/MemoPopup.kt
@@ -29,6 +29,10 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.hsk.ktx.date.Date
 import com.practice.designsystem.LightAndDarkPreview
@@ -205,7 +209,10 @@ private fun PopupElementItem(
                     IconButton(onClick = { onTextChange("") }) {
                         Icon(
                             imageVector = Icons.Outlined.Clear,
-                            contentDescription = stringResource(id = R.string.memo_popup_clear_text, text),
+                            contentDescription = stringResource(
+                                id = R.string.memo_popup_clear_text,
+                                text
+                            ),
                         )
                     }
                 }
@@ -222,12 +229,20 @@ private fun AddMemoButton(
     textColor: Color,
     modifier: Modifier = Modifier
 ) {
-    Box(modifier = modifier) {
+    val a11yDescription = stringResource(id = R.string.memo_popup_add_memo_description)
+    Box(
+        modifier = modifier.semantics {
+            role = Role.Button
+        }
+    ) {
         LabelLarge(
             text = stringResource(id = R.string.memo_popup_add_memo),
             modifier = Modifier
                 .align(Alignment.Center)
-                .padding(vertical = 16.dp),
+                .padding(vertical = 16.dp)
+                .semantics {
+                    contentDescription = a11yDescription
+                },
             textColor = textColor,
         )
     }

--- a/feature/main/src/main/res/values/strings.xml
+++ b/feature/main/src/main/res/values/strings.xml
@@ -54,6 +54,7 @@
 
     <string name="memo_popup_title">%d월 %d일 메모 편집</string>
     <string name="memo_popup_add_memo">+ 메모 추가하기</string>
+    <string name="memo_popup_add_memo_description">메모 추가하기. 이 버튼 바로 위에 새 메모를 추가합니다.</string>
     <string name="memo_popup_item_label">일정 입력</string>
     <string name="memo_popup_clear_text">내용 지우기 %s</string>
     <string name="memo_popup_item_delete">삭제하기 %s</string>


### PR DESCRIPTION
## 문제 상황

한소네에서 메모 팝업에서 메모 추가 버튼을 클릭했을 때, 아무런 점자 또는 음성 가이드가 없어 메모가 추가됐는지 알 수 없다. 

사실 Toast 메시지를 보여주긴 하지만, 한소네는 토스트 메시지를 읽어주지 않는다.

## 해결 방법

메모가 추가됐을 때 효과음을 넣을까 고민했으나, 일단 소리로는 안내하지 않도록 수정했다. 

대신 메모 추가 버튼에 다음과 같이 description을 추가했다.
```
메모 추가하기. 이 버튼 바로 위에 새 메모를 추가합니다.
```

## 수정한 내용

* 메모 추가하기 버튼에 자세한 description 추가
