### PR TITLE
feature: 큰 글씨 대응

### DIFF
--- a/core/designsystem/src/main/java/com/practice/designsystem/a11y/LocalDensityUtil.kt
+++ b/core/designsystem/src/main/java/com/practice/designsystem/a11y/LocalDensityUtil.kt
@@ -1,0 +1,11 @@
+package com.practice.designsystem.a11y
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.Density
+
+/***
+ * 기기의 폰트 크기가 새로운 UI가 필요할 정도로 큰 지 판별한다.
+ * 이 값이 `true`라면 큰 글씨에도 대응하는 UI를 보여줄 필요가 있다.
+ */
+val Density.isLargeFont: Boolean
+    @Composable get() = this.fontScale >= 1.6

--- a/feature/main/src/main/java/com/practice/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/practice/main/MainScreen.kt
@@ -11,8 +11,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
+import com.practice.designsystem.a11y.isLargeFont
 import com.practice.main.calendar.CalendarMainScreen
 import com.practice.main.daily.DailyMainScreen
 import com.practice.main.loading.LoadingMainScreen
@@ -83,7 +85,11 @@ fun MainScreen(
 }
 
 val WindowSizeClass.mealColumns: Int
-    get() = if (this.widthSizeClass == WindowWidthSizeClass.Compact) 2 else 3
+    @Composable get() = when {
+        LocalDensity.current.isLargeFont -> 1
+        this.widthSizeClass == WindowWidthSizeClass.Compact -> 2
+        else -> 3
+    }
 
 @Composable
 private fun MainScreenPopups(

--- a/feature/main/src/main/java/com/practice/main/MainScreenElements.kt
+++ b/feature/main/src/main/java/com/practice/main/MainScreenElements.kt
@@ -118,9 +118,10 @@ private fun MainTopBarActions(
     onSettingsIconClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val horizontalSpace = if (LocalDensity.current.isLargeFont) 0.dp else 4.dp
     Row(
         modifier = modifier.padding(16.dp),
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        horizontalArrangement = Arrangement.spacedBy(horizontalSpace),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         ForceRefreshIcon(

--- a/feature/main/src/main/java/com/practice/main/MainScreenElements.kt
+++ b/feature/main/src/main/java/com/practice/main/MainScreenElements.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.clearAndSetSemantics
@@ -58,6 +59,7 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.hsk.ktx.date.Date
 import com.practice.designsystem.LightAndDarkPreview
+import com.practice.designsystem.a11y.isLargeFont
 import com.practice.designsystem.components.BodyLarge
 import com.practice.designsystem.components.LabelLarge
 import com.practice.designsystem.components.TitleLarge
@@ -478,12 +480,39 @@ private fun MainScreenContentHeader(
     buttonTitle: String = "",
     onButtonClick: () -> Unit = {},
 ) {
-    Row(
+    if (LocalDensity.current.isLargeFont) {
+        MainScreenContentHeaderLargeFont(
+            modifier = modifier,
+            titleContent = titleContent,
+            buttonTitle = buttonTitle,
+            onButtonClick = onButtonClick,
+        )
+    } else {
+        Row(
+            modifier = modifier,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            titleContent()
+            Spacer(modifier = Modifier.weight(1f))
+            if (buttonTitle != "") {
+                MainScreenContentHeaderButton(title = buttonTitle, onButtonClick = onButtonClick)
+            }
+        }
+    }
+}
+
+@Composable
+private fun MainScreenContentHeaderLargeFont(
+    modifier: Modifier = Modifier,
+    titleContent: @Composable () -> Unit = {},
+    buttonTitle: String = "",
+    onButtonClick: () -> Unit = {},
+) {
+    Column(
         modifier = modifier,
-        verticalAlignment = Alignment.CenterVertically,
+        verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         titleContent()
-        Spacer(modifier = Modifier.weight(1f))
         if (buttonTitle != "") {
             MainScreenContentHeaderButton(title = buttonTitle, onButtonClick = onButtonClick)
         }

--- a/feature/main/src/main/java/com/practice/main/daily/components/DailyModeElements.kt
+++ b/feature/main/src/main/java/com/practice/main/daily/components/DailyModeElements.kt
@@ -4,8 +4,11 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -40,7 +43,8 @@ internal fun DateQuickNavigationButtons(
     navigationElements: Collection<DateQuickNavigation> = DateQuickNavigation.entries,
 ) {
     Row(
-        modifier = modifier,
+        modifier = modifier
+            .height(IntrinsicSize.Max),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -48,7 +52,9 @@ internal fun DateQuickNavigationButtons(
             DateQuickNavigationButton(
                 datePickerState = datePickerState,
                 quickNavigation = it,
-                modifier = Modifier.weight(1f),
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxHeight(),
             )
         }
     }

--- a/feature/main/src/main/java/com/practice/main/popup/NutrientPopup.kt
+++ b/feature/main/src/main/java/com/practice/main/popup/NutrientPopup.kt
@@ -30,12 +30,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.unit.dp
 import com.hsk.ktx.date.Date
 import com.practice.designsystem.LightAndDarkPreview
+import com.practice.designsystem.a11y.isLargeFont
 import com.practice.designsystem.theme.BlindarTheme
 import com.practice.main.R
 import com.practice.main.previewMenus
@@ -54,7 +56,7 @@ fun NutrientPopup(
     modifier: Modifier = Modifier
 ) {
     val chipTargetNames = listOf("열량", "탄수화물", "단백질", "지방")
-    val (chipNutrients, listNutrients) = uiMeal.nutrients.partition { nutrient ->
+    val (importantNutrients, otherNutrients) = uiMeal.nutrients.partition { nutrient ->
         chipTargetNames.contains(nutrient.name)
     }
 
@@ -82,9 +84,9 @@ fun NutrientPopup(
         }
         item {
             Column(modifier = Modifier.fillMaxWidth()) {
-                NutrientChipGrid(chipNutrients.toImmutableList())
+                ImportantNutrients(importantNutrients.toImmutableList())
                 NutrientList(
-                    nutrients = listNutrients.toImmutableList(),
+                    nutrients = otherNutrients.toImmutableList(),
                     modifier = Modifier.padding(top = 8.dp),
                 )
             }
@@ -95,6 +97,24 @@ fun NutrientPopup(
                 modifier = Modifier.fillMaxWidth(),
             )
         }
+    }
+}
+
+@Composable
+private fun ImportantNutrients(
+    importantNutrients: ImmutableList<Nutrient>,
+    modifier: Modifier = Modifier,
+) {
+    if (LocalDensity.current.isLargeFont) {
+        NutrientList(
+            nutrients = importantNutrients,
+            modifier = modifier,
+        )
+    } else {
+        NutrientChipGrid(
+            nutrients = importantNutrients,
+            modifier = modifier,
+        )
     }
 }
 


### PR DESCRIPTION
## 문제 상황

저시력 사용자들을 위해 큰 글씨 UI를 다듬을 필요가 있다.

## 해결 방법

시스템 폰트가 클 때, 각 컴포넌트에서 적절한 UI를 보여준다.

![image](https://github.com/blinder-23/blindar-android/assets/45386920/d6d5f7c9-0fd5-4eff-8018-843ef28cd9eb)

![image](https://github.com/blinder-23/blindar-android/assets/45386920/0c7f39b2-5ed0-4609-8ba0-6b8665e19afc)

## 수정한 내용

* 0189a69e1359adfe3f4da6ddbaf5bb11b8cfc4c2: `LocalDensity.current.fontScale`이 1.6 이상이면 `큰 글씨`라고 판단하는 기능 추가
* d5860028df1be154b984d1ba886a2e42947e8c42: 식단을 1줄로 보여줌
* 26bb96b9e3e4e29dba1153d3cf961f0a790749a3: 식단 헤더(식단 시간, 영양 버튼)를 2줄로 보여줌
* d8682d7bebde4c11f6351a0a5de58ab12fbfc772: 중요 영양소도 리스트로 보여주도록 수정
* 7d458f6eac758fdc3f63547cb59aaf460034eab3: 메인 화면 TopAppBar의 새로고침과 설정 아이콘의 간격을 좁힘 (`떨어트림`은 잘못 적은 것)