### PR TITLE
fix: TextField에 개행 문자가 들어갈 수 없도록 수정

### DIFF
--- a/core/util/src/main/java/com/practice/util/StringUtil.kt
+++ b/core/util/src/main/java/com/practice/util/StringUtil.kt
@@ -1,0 +1,9 @@
+package com.practice.util
+
+
+/**
+ * 문자열에서 개행문자, 탭 문자, 공백 한 칸을 제거한다.
+ */
+fun String.removeWhitespaces(): String {
+    return this.filter { it != '\n' && it != '\t' && it != ' ' }
+}

--- a/feature/register/src/main/java/com/practice/register/RegisterViewModel.kt
+++ b/feature/register/src/main/java/com/practice/register/RegisterViewModel.kt
@@ -15,6 +15,7 @@ import com.practice.firebase.BlindarUserStatus
 import com.practice.preferences.PreferencesRepository
 import com.practice.register.phonenumber.PhoneNumberValidator
 import com.practice.user.RegisterManager
+import com.practice.util.removeWhitespaces
 import com.practice.util.update
 import com.practice.work.BlindarWorkManager
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -148,7 +149,7 @@ class RegisterViewModel @Inject constructor(
      */
     fun onNameChange(name: String) {
         registerUiState.update {
-            this.copy(name = name)
+            this.copy(name = name.removeWhitespaces())
         }
     }
 
@@ -188,10 +189,11 @@ class RegisterViewModel @Inject constructor(
     }
 
     fun onSchoolQueryChange(query: String) {
+        val queryWithoutWhitespaces = query.removeWhitespaces()
         registerUiState.update {
-            this.copy(schoolQuery = query)
+            this.copy(schoolQuery = queryWithoutWhitespaces)
         }
-        updateSchoolList(query)
+        updateSchoolList(queryWithoutWhitespaces)
     }
 
     private fun updateSchoolList(query: String) {

--- a/feature/register/src/main/java/com/practice/register/phonenumber/VerifyPhoneNumber.kt
+++ b/feature/register/src/main/java/com/practice/register/phonenumber/VerifyPhoneNumber.kt
@@ -302,7 +302,7 @@ private fun AuthCodeTextField(
                 verifyAuthCode()
             },
         ),
-        maxLines = 1,
+        singleLine = true,
     )
 }
 

--- a/feature/register/src/main/java/com/practice/register/registerform/RegisterFormScreen.kt
+++ b/feature/register/src/main/java/com/practice/register/registerform/RegisterFormScreen.kt
@@ -174,7 +174,7 @@ private fun NameTextField(
                 submitName()
             }
         ),
-        maxLines = 1,
+        singleLine = true,
     )
 }
 

--- a/feature/register/src/main/java/com/practice/register/selectschool/SelectSchoolScreen.kt
+++ b/feature/register/src/main/java/com/practice/register/selectschool/SelectSchoolScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.outlined.Cancel
@@ -20,6 +21,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.practice.designsystem.LightAndDarkPreview
@@ -126,7 +128,9 @@ private fun SearchSchoolTextField(
                     )
                 }
             }
-        }
+        },
+        singleLine = true,
+        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
     )
 }
 


### PR DESCRIPTION
## 문제 상황

한소네 사용자들은 텍스트를 입력한 후에 습관적으로 엔터를 누르곤 하는데, `\n` 문자를 입력하려는 의도가 아님에도 불구하고 개행 문자가 문자열에 포함되어 혼란을 주는 경우가 있었다.

## 해결 방법

닉네임, 학교 검색 TextField에 개행 문자가 포함되지 않도록 수정했다. `ViewModel`에서 개행 문자가 포함된 문자열에서 개행 문자, 탭, 공백을 제거하여 ui state에 반영되도록 수정했다.

## 수정한 내용

* 7a8bc6aa4c0c5f5dbfe178147437cbfd4733b9a5: 문자열에서 `\n`, `\t`, ` `를 제거하는 String 확장 함수 추가
* 75ae0d85e3528e83de6d25d29610e76c8b4e953b: 닉네임, 학교 검색 UiState에 개행 문자를 제거한 문자열이 들어가도록 수정
* 6fca0a048c1d3278d3d15174faab13df292cb7ad: 학교 검색 `TextField`가 입력을 한 줄로만 보여주도록 수정 (`singleLine = true`)
* e4971db9a64a46d549c10b9d180aaf6d52674643: 입력을 한 줄로 보여주는 기능을 `maxLines = 1` 대신 `singleLine = true`로 통일