### PR TITLE
fix: 가독성이 낮은 버튼 색 수정

### DIFF
--- a/feature/main/src/main/java/com/practice/main/MainScreenElements.kt
+++ b/feature/main/src/main/java/com/practice/main/MainScreenElements.kt
@@ -593,13 +593,14 @@ private fun MealTimesButton(
     endRoundCornerPercent: Int = 0,
 ) {
     val backgroundColor by animateColorAsState(
-        targetValue = if (isSelected) MaterialTheme.colorScheme.primary else Color.Transparent,
+        targetValue = if (isSelected) MaterialTheme.colorScheme.primaryContainer else Color.Transparent,
         label = "background",
     )
-    val contentColor by animateColorAsState(
-        targetValue = if (isSelected) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onPrimaryContainer,
-        label = "content",
+    val contentAlpha by animateFloatAsState(
+        targetValue = if (isSelected) 1f else 0.6f,
+        label = "alpha",
     )
+    val contentColor = MaterialTheme.colorScheme.onPrimaryContainer
     val shape = RoundedCornerShape(
         topStartPercent = startRoundCornerPercent,
         topEndPercent = endRoundCornerPercent,
@@ -627,6 +628,7 @@ private fun MealTimesButton(
         LabelLarge(
             text = mealTime,
             textColor = contentColor,
+            modifier = Modifier.alpha(contentAlpha),
         )
     }
 }

--- a/feature/main/src/main/java/com/practice/main/MainScreenElements.kt
+++ b/feature/main/src/main/java/com/practice/main/MainScreenElements.kt
@@ -3,9 +3,11 @@ package com.practice.main
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.CubicBezierEasing
 import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -41,6 +43,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
@@ -526,11 +529,12 @@ private fun MainScreenContentHeaderButton(
     onButtonClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val backgroundColor = MaterialTheme.colorScheme.primary
+    val backgroundColor = MaterialTheme.colorScheme.primaryContainer
     Button(
         onClick = onButtonClick,
         modifier = modifier,
         colors = ButtonDefaults.buttonColors(containerColor = backgroundColor),
+        border = BorderStroke(width = 2.dp, color = MaterialTheme.colorScheme.primary),
     ) {
         LabelLarge(
             text = title,
@@ -666,7 +670,9 @@ private fun MainScreenContentHeaderButtonPreview() {
         MainScreenContentHeaderButton(
             title = "영양 정보",
             onButtonClick = {},
-            modifier = Modifier.padding(16.dp),
+            modifier = Modifier
+                .background(MaterialTheme.colorScheme.surface)
+                .padding(16.dp),
         )
     }
 }

--- a/feature/main/src/main/java/com/practice/main/daily/components/DailyModeElements.kt
+++ b/feature/main/src/main/java/com/practice/main/daily/components/DailyModeElements.kt
@@ -1,6 +1,7 @@
 package com.practice.main.daily.components
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -66,10 +67,12 @@ internal fun DateQuickNavigationButton(
     quickNavigation: DateQuickNavigation,
     modifier: Modifier = Modifier,
 ) {
-    val backgroundColor = MaterialTheme.colorScheme.primary
+    val shape = RoundedCornerShape(6.dp)
+    val backgroundColor = MaterialTheme.colorScheme.primaryContainer
     Box(
         modifier = modifier
-            .clip(RoundedCornerShape(6.dp))
+            .clip(shape)
+            .border(2.dp, MaterialTheme.colorScheme.primary, shape)
             .background(backgroundColor)
             .clickable(onClickLabel = stringResource(id = quickNavigation.descriptionId)) {
                 if (quickNavigation == DateQuickNavigation.TODAY) {
@@ -151,7 +154,10 @@ private fun DateQuickNavigationButtonsPreview() {
     BlindarTheme {
         DateQuickNavigationButtons(
             datePickerState = datePickerState,
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .background(MaterialTheme.colorScheme.surface)
+                .padding(16.dp)
+                .fillMaxWidth(),
         )
     }
 }


### PR DESCRIPTION
## 문제 상황

빠른 날짜 탐색, 영양 정보 등 몇몇 버튼의 가독성이 좋지 않은 문제가 있었다. 구체적으로는 배경색이 너무 밝아 저시력 사용자가 글씨를 인식하기 어려웠다.

## 해결 방법

`밝은 배경, 어두운 글씨`의 조합을 `어두운 배경, 밝은 글씨`로 수정했고, 버튼임을 명확히 드러내기 위해 테두리를 추가했다.

![image](https://github.com/blinder-23/blindar-android/assets/45386920/2fef77ce-72d2-4f5b-b9f7-470da78d626d)


## 수정한 내용

커밋 참고
