### PR TITLE
fix: 시스템 글씨가 일정 크기 이상일 때 영양정보 팝업의 글씨를 더 키움

### DIFF
--- a/core/designsystem/src/main/java/com/practice/designsystem/theme/PopupTypography.kt
+++ b/core/designsystem/src/main/java/com/practice/designsystem/theme/PopupTypography.kt
@@ -41,6 +41,11 @@ val PopupTypography = Typography(
         fontWeight = FontWeight.SemiBold,
         fontSize = 20.sp,
     ),
+    bodyLarge = TextStyle(
+        fontFamily = popupFontFamily,
+        fontWeight = FontWeight.Medium,
+        fontSize = 24.sp,
+    ),
     bodyMedium = TextStyle(
         fontFamily = popupFontFamily,
         fontWeight = FontWeight.Medium,

--- a/feature/main/src/main/java/com/practice/main/popup/NutrientPopup.kt
+++ b/feature/main/src/main/java/com/practice/main/popup/NutrientPopup.kt
@@ -1,5 +1,6 @@
 package com.practice.main.popup
 
+import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -34,6 +35,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hsk.ktx.date.Date
 import com.practice.designsystem.LightAndDarkPreview
@@ -164,19 +166,53 @@ private fun NutrientListItem(
     nutrient: Nutrient,
     modifier: Modifier = Modifier,
 ) {
-    val textColor = contentColorFor(MaterialTheme.colorScheme.surface)
-    Row(modifier = modifier
-        .clearAndSetSemantics {
-            contentDescription = nutrient.description
-        }
-        .padding(16.dp)
-    ) {
+    val itemModifier = modifier.clearAndSetSemantics {
+        contentDescription = nutrient.description
+    }
+    if (LocalDensity.current.isLargeFont) {
+        NutrientListItemLarge(
+            nutrient = nutrient,
+            modifier = itemModifier,
+        )
+    } else {
+        NutrientListItemNormal(
+            nutrient = nutrient,
+            modifier = itemModifier,
+        )
+    }
+}
+
+@Composable
+private fun NutrientListItemNormal(
+    nutrient: Nutrient,
+    modifier: Modifier = Modifier,
+    textColor: Color = contentColorFor(MaterialTheme.colorScheme.surface),
+) {
+    Row(modifier = modifier.padding(16.dp)) {
         PopupBodySmall(
             text = nutrient.name,
             color = textColor
         )
         Spacer(modifier = Modifier.weight(1f))
         PopupBodySmall(
+            text = "${nutrient.amount} ${nutrient.unit}",
+            color = textColor,
+        )
+    }
+}
+
+@Composable
+private fun NutrientListItemLarge(
+    nutrient: Nutrient,
+    modifier: Modifier = Modifier,
+    textColor: Color = contentColorFor(MaterialTheme.colorScheme.surface),
+) {
+    Column(modifier = modifier) {
+        PopupBodyLarge(
+            text = nutrient.name,
+            color = textColor
+        )
+        PopupBodyLarge(
             text = "${nutrient.amount} ${nutrient.unit}",
             color = textColor,
         )
@@ -324,5 +360,19 @@ private fun NutrientPopupPreview() {
                     .align(Alignment.Center),
             )
         }
+    }
+}
+
+@Preview(fontScale = 2f)
+@Preview(fontScale = 2f, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun NutrientListItemLargePreview() {
+    BlindarTheme {
+        NutrientListItemLarge(
+            nutrient = previewNutrients[0],
+            modifier = Modifier
+                .background(MaterialTheme.colorScheme.surface)
+                .padding(16.dp),
+        )
     }
 }

--- a/feature/main/src/main/java/com/practice/main/popup/PopupComponents.kt
+++ b/feature/main/src/main/java/com/practice/main/popup/PopupComponents.kt
@@ -34,6 +34,20 @@ fun PopupTitleLarge(
 }
 
 @Composable
+fun PopupBodyLarge(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+) {
+    PopupText(
+        text = text,
+        textStyle = PopupTypography.bodyLarge,
+        modifier = modifier,
+        color = color,
+    )
+}
+
+@Composable
 fun PopupBodyMedium(
     text: String,
     modifier: Modifier = Modifier,


### PR DESCRIPTION
## 문제 상황

시스템 글씨 크기를 최대로 했을 때 저시력 사용자들이 영양 정보 팝업의 제목은 인식할 수 있지만, 내용을 명확하게 인식하기 어려웠다.

## 해결 방법

시스템 글씨가 클 때, 내용의 글씨 크기를 제목 수준으로 대폭 키우고, 영양 이름과 양도 가로가 아닌 세로로 배치했다. 

![nutrient_popup](https://github.com/blinder-23/blindar-android/assets/45386920/f99aba7d-d683-4ac2-85f5-f240de2ecc65)


## 수정한 내용

* 4dba5784bca57ca4abc3c90be3e707a64dc0ccca: `PopupBodyLarge` composable 추가
* c492e44a459a5b3bb9d4654aca7c35b6a29cfffc: 시스템 글씨가 일정 크기 이상일 때, 텍스트를 `PopupBodyMedium` 대신 `PopupBodyLarge`를 사용하여 보여주고, 가로가 아닌 세로로 배치