### PR TITLE
fix: 이제 하루에 여러 개의 식단을 보여줄 수 있음

### DIFF
--- a/feature/main/src/main/java/com/practice/main/MainScreenViewModel.kt
+++ b/feature/main/src/main/java/com/practice/main/MainScreenViewModel.kt
@@ -141,7 +141,7 @@ class MainScreenViewModel @Inject constructor(
         updateUiState(
             yearMonth = clickedDate.yearMonth,
             selectedDate = clickedDate,
-            selectedMealIndex = 0, // TODO: real?
+            selectedMealIndex = 0,
         )
     }
 

--- a/feature/main/src/main/java/com/practice/main/state/MainUiState.kt
+++ b/feature/main/src/main/java/com/practice/main/state/MainUiState.kt
@@ -33,7 +33,7 @@ data class MainUiState(
         get() = !selectedDateDataState.uiMeals.isEmpty
 
     val isScheduleOrMemoExists: Boolean
-        get()=selectedDateDataState.memoPopupElements.isNotEmpty()
+        get() = selectedDateDataState.memoPopupElements.isNotEmpty()
 
     fun updateMemoUiState(date: Date, uiMemos: UiMemos): List<DailyData> {
         return if (monthlyDataState.any { it.date == date }) {

--- a/feature/main/src/main/java/com/practice/main/state/UiMeal.kt
+++ b/feature/main/src/main/java/com/practice/main/state/UiMeal.kt
@@ -9,7 +9,6 @@ import kotlinx.collections.immutable.toPersistentList
 /**
  * Ui state of meal
  */
-// TODO: 향후 하루에 여러 개의 식단을 지우너하게 되면 UiMeals 추가하기
 data class UiMeal(
     val year: Int,
     val month: Int,
@@ -23,6 +22,14 @@ data class UiMeal(
 
     val description: String
         get() = if (menus.isEmpty()) "식단이 없습니다." else menus.joinToString(", ") { it.name }
+
+    val sortOrder: Int
+        get() = when (mealTime) {
+            "조식" -> 0
+            "중식" -> 1
+            "석식" -> 2
+            else -> 10
+        }
 
     companion object {
         val EmptyUiMeal = UiMeal(

--- a/feature/main/src/main/java/com/practice/main/state/UiMeals.kt
+++ b/feature/main/src/main/java/com/practice/main/state/UiMeals.kt
@@ -4,7 +4,7 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import java.io.Serializable
 
-class UiMeals(meals: List<UiMeal>): Serializable {
+class UiMeals(meals: List<UiMeal>) : Serializable {
 
     constructor(vararg meals: UiMeal) : this(meals.toList())
 
@@ -22,6 +22,6 @@ class UiMeals(meals: List<UiMeal>): Serializable {
     operator fun get(index: Int) = meals[index]
 
     private fun List<UiMeal>.sortMealsInTimeOrder(): ImmutableList<UiMeal> {
-        return this.toImmutableList()
+        return this.sortedBy { it.sortOrder }.toImmutableList()
     }
 }


### PR DESCRIPTION
## 문제 상황

서버 측 크롤링의 문제 때문에 하루에 여러 개의 식단이 있어도 맨 마지막 식단만 보여줄 수 있었다. 그러다가 서버 문제가 해결되어 이제 하루에 여러 개의 식단을 보내줄 수 있게 되었다.

## 해결 방법

이제 앱에서도 여러 개의 식단을 보여줄 수 있다. 모든 학교에서 `조식`, `중식`, `석식`이라는 단어를 사용하고 있어, 이 단어들을 사용하여 식단을 정렬하여 보여준다.

## 수정한 내용

* 5e1aba404c24d1bf16a704dde6cdf4f17b795bfe: 식단이 여러 개 있을 때, 조식, 중식, 석식 순서대로 식단을 보여준다.
