### PR TITLE
fix: 빠른 탐색 버튼의 저시력 시인성 향상

### DIFF
--- a/core/designsystem/src/main/java/com/practice/designsystem/components/Text.kt
+++ b/core/designsystem/src/main/java/com/practice/designsystem/components/Text.kt
@@ -236,7 +236,8 @@ fun BodyMedium(
 fun BodySmall(
     text: String,
     modifier: Modifier = Modifier,
-    textColor: Color = MaterialTheme.colorScheme.onSurface
+    textColor: Color = MaterialTheme.colorScheme.onSurface,
+    fontWeight: FontWeight? = null,
 ) {
     Text(
         text = text,
@@ -244,5 +245,6 @@ fun BodySmall(
         style = MaterialTheme.typography.bodySmall,
         color = textColor,
         fontFamily = NanumSquareRound,
+        fontWeight = fontWeight,
     )
 }

--- a/feature/main/src/main/java/com/practice/main/daily/components/DailyModeElements.kt
+++ b/feature/main/src/main/java/com/practice/main/daily/components/DailyModeElements.kt
@@ -23,13 +23,16 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.practice.designsystem.LightAndDarkPreview
+import com.practice.designsystem.a11y.isLargeFont
 import com.practice.designsystem.components.BodySmall
 import com.practice.designsystem.theme.BlindarTheme
 import com.practice.main.R
@@ -92,6 +95,7 @@ internal fun DateQuickNavigationButton(
             text = stringResource(id = quickNavigation.nameId),
             modifier = Modifier.align(Alignment.Center),
             textColor = contentColorFor(backgroundColor = backgroundColor),
+            fontWeight = if (LocalDensity.current.isLargeFont) FontWeight.Bold else null,
         )
     }
 }


### PR DESCRIPTION
## 문제 상황

빠른 탐색 버튼의 글씨가 _여전히_ 잘 보이지 않는다는 피드백이 있었다. 글씨가 얇기 때문.

![image](https://github.com/blinder-23/blindar-android/assets/45386920/7d4218e8-b9df-4310-8462-c0af458d06c1)


## 해결 방법

시스템 글씨 크기가 클 때 빠른 탐색 버튼의 텍스트를 볼드체로 표시하도록 수정했다.

![image](https://github.com/blinder-23/blindar-android/assets/45386920/684e2063-ff4f-42ef-8d15-8c37b7418554)


## 수정한 내용

* 759d540f5fa9eb070152ee3a075708dc47be3836: `LocalDensity.current.isLargeFont`가 `true`일 때 텍스트를 볼드체로 보여주도록 수정했다.
