### PR TITLE
fix: Google 접근성 도구 검사 결과 반영

### DIFF
--- a/core/designsystem/src/main/java/com/practice/designsystem/components/AppIcon.kt
+++ b/core/designsystem/src/main/java/com/practice/designsystem/components/AppIcon.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import com.practice.designsystem.LightPreview
+import com.practice.designsystem.LightAndDarkPreview
 import com.practice.designsystem.R
 import com.practice.designsystem.theme.BlindarTheme
 
@@ -29,7 +29,7 @@ fun AppIcon(
         )
         TitleMedium(
             text = "CALENDAR FOR BLIND",
-            textColor = MaterialTheme.colorScheme.outlineVariant,
+            textColor = MaterialTheme.colorScheme.onSurface,
             modifier = Modifier.padding(top = 8.dp),
         )
         DisplayMedium(
@@ -39,14 +39,14 @@ fun AppIcon(
     }
 }
 
-@LightPreview
+@LightAndDarkPreview
 @Composable
 private fun AppIconPreview() {
     BlindarTheme {
         AppIcon(
             modifier = Modifier
-                .padding(16.dp)
-                .background(MaterialTheme.colorScheme.surface),
+                .background(MaterialTheme.colorScheme.surface)
+                .padding(16.dp),
         )
     }
 }


### PR DESCRIPTION
## 문제 상황

Google의 접근성 검사기를 활용하여 앱의 접근성을 증진하고자 하였다.

## 해결 방법

놀랍게도 수정이 필요한 문제는 단 하나뿐이었고, 나머지는 문제를 파악하기 어렵거나 의도된 것들이었다.

스플래시 화면에서 `CALENDAR FOR BLIND` 문구의 가시성이 낮다는 검사 결과가 있어 수정하였다.

![image](https://github.com/blinder-23/blindar-android/assets/45386920/8804421e-ff10-4179-acd2-ec8f9210029c)


## 수정한 내용

* 3da62f998a4899a7151a505528a56794d7459462: 스플래시 화면의 문구를 가시성이 높은 색으로 교체