### PR TITLE
fix: 모바일 앱 콘텐츠 접근성 가이드라인 2.0 반영

### DIFF
--- a/feature/register/src/main/res/values/strings.xml
+++ b/feature/register/src/main/res/values/strings.xml
@@ -6,10 +6,10 @@
     <string name="next_button">다음</string>
 
     <string name="phone_number_title">휴대폰 번호</string>
-    <string name="phone_number_label">휴대폰 번호</string>
+    <string name="phone_number_label">휴대폰 번호 입력</string>
     <string name="invalid_phone_number">올바르지 않은 휴대폰 번호입니다.</string>
     <string name="auth_chip_label">인증 요청</string>
-    <string name="auth_code_field_label">인증 번호</string>
+    <string name="auth_code_field_label">인증 번호 입력</string>
     <string name="auth_code_sent">인증 코드가 발송되었습니다. 2분 안에 입력해 주세요.</string>
     <string name="invalid_code">인증 코드가 올바르지 않습니다.</string>
     <string name="auth_code_fail">코드 발송에 실패했습니다. 잠시 후 다시 시도해 주세요.</string>


### PR DESCRIPTION
## 문제 상황

모바일 앱 콘텐츠 접근성 2.0의 내용을 살펴보고, 반영할 내용이 있는지 확인해 보았다.

## 해결 방법

대부분의 내용을 잘 지키고 있었다. 텍스트 라벨 하나만 수정했다.

## 수정한 내용

* f457eebd3ac56ba8648009aa395a13d519942133: 완전히 동일한 2개의 텍스트 라벨을 서로 구분되게 바꿈
