### PR TITLE
refactor: credential manager로 migrate

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,12 +23,12 @@ tasks.withType<KotlinCompile>().configureEach {
 }
 
 android {
-    compileSdk = 34
+    compileSdkPreview = "VanillaIceCream"
 
     defaultConfig {
         applicationId = "com.practice.hanbitlunch"
         minSdk = 26
-        targetSdk = 34
+        targetSdk = 35
         versionCode = 1
         versionName = "2.4.4"
         signingConfig = signingConfigs.getByName("debug")

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -92,3 +92,16 @@
 -keepclasseswithmembers class com.google.firebase.FirebaseException
 -if class androidx.credentials.CredentialManager
 -keep class androidx.credentials.playservices.** {*;}
+
+# Temporary rules
+-dontwarn com.google.android.gms.auth.api.credentials.Credential$Builder
+-dontwarn com.google.android.gms.auth.api.credentials.Credential
+-dontwarn com.google.android.gms.auth.api.credentials.CredentialRequest$Builder
+-dontwarn com.google.android.gms.auth.api.credentials.CredentialRequest
+-dontwarn com.google.android.gms.auth.api.credentials.CredentialRequestResponse
+-dontwarn com.google.android.gms.auth.api.credentials.Credentials
+-dontwarn com.google.android.gms.auth.api.credentials.CredentialsClient
+-dontwarn com.google.android.gms.auth.api.credentials.CredentialsOptions$Builder
+-dontwarn com.google.android.gms.auth.api.credentials.CredentialsOptions
+-dontwarn com.google.android.gms.auth.api.credentials.HintRequest$Builder
+-dontwarn com.google.android.gms.auth.api.credentials.HintRequest

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -90,3 +90,5 @@
 -keep public class com.google.firebase.** {*;}
 -keep class com.google.android.gms.internal.** {*;}
 -keepclasseswithmembers class com.google.firebase.FirebaseException
+-if class androidx.credentials.CredentialManager
+-keep class androidx.credentials.playservices.** {*;}

--- a/app/src/main/java/com/practice/hanbitlunch/BlindarNavHost.kt
+++ b/app/src/main/java/com/practice/hanbitlunch/BlindarNavHost.kt
@@ -14,6 +14,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.IntOffset
+import androidx.credentials.CredentialManager
+import androidx.credentials.GetCredentialRequest
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
@@ -21,7 +23,6 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
-import com.google.android.gms.auth.api.signin.GoogleSignInClient
 import com.practice.hanbitlunch.navigation.memoRoute
 import com.practice.hanbitlunch.navigation.nutrientRoute
 import com.practice.main.main.MainScreen
@@ -45,7 +46,8 @@ private const val TAG = "BlindarNavHost"
 @Composable
 fun BlindarNavHost(
     windowSizeClass: WindowSizeClass,
-    googleSignInClient: GoogleSignInClient,
+    getCredentialManager: () -> CredentialManager,
+    signInWithGoogleRequest: GetCredentialRequest,
     modifier: Modifier = Modifier,
     navController: NavHostController = rememberNavController(),
     onNavigateToMainScreen: () -> Unit = {},
@@ -104,8 +106,9 @@ fun BlindarNavHost(
         blindarMainNavGraph(
             navController = navController,
             windowSizeClass = windowSizeClass,
-            googleSignInClient = googleSignInClient,
             onNavigateToMainScreen = onNavigateToMainScreen,
+            getCredentialManager = getCredentialManager,
+            signInWithGoogleRequest = signInWithGoogleRequest,
         )
     }
 }
@@ -113,8 +116,9 @@ fun BlindarNavHost(
 fun NavGraphBuilder.blindarMainNavGraph(
     navController: NavHostController,
     windowSizeClass: WindowSizeClass,
-    googleSignInClient: GoogleSignInClient,
     onNavigateToMainScreen: () -> Unit,
+    getCredentialManager: () -> CredentialManager,
+    signInWithGoogleRequest: GetCredentialRequest,
 ) {
     val onLoginSuccess = {
         navController.navigate(MainRoute) {
@@ -172,7 +176,8 @@ fun NavGraphBuilder.blindarMainNavGraph(
             onFail = {
                 context.makeToast(failMessage)
             },
-            googleSignInClient = googleSignInClient,
+            credentialManager = getCredentialManager(),
+            signInWithGoogleRequest = signInWithGoogleRequest,
             modifier = Modifier
                 .safeDrawingPadding()
                 .fillMaxSize()

--- a/app/src/main/java/com/practice/hanbitlunch/BlindarNavHost.kt
+++ b/app/src/main/java/com/practice/hanbitlunch/BlindarNavHost.kt
@@ -46,7 +46,6 @@ private const val TAG = "BlindarNavHost"
 @Composable
 fun BlindarNavHost(
     windowSizeClass: WindowSizeClass,
-    getCredentialManager: () -> CredentialManager,
     signInWithGoogleRequest: GetCredentialRequest,
     modifier: Modifier = Modifier,
     navController: NavHostController = rememberNavController(),
@@ -56,6 +55,7 @@ fun BlindarNavHost(
         durationMillis = 500,
     )
 
+    val context = LocalContext.current
     NavHost(
         navController = navController,
         startDestination = SplashRoute,
@@ -107,7 +107,7 @@ fun BlindarNavHost(
             navController = navController,
             windowSizeClass = windowSizeClass,
             onNavigateToMainScreen = onNavigateToMainScreen,
-            getCredentialManager = getCredentialManager,
+            credentialManager = CredentialManager.create(context),
             signInWithGoogleRequest = signInWithGoogleRequest,
         )
     }
@@ -117,7 +117,7 @@ fun NavGraphBuilder.blindarMainNavGraph(
     navController: NavHostController,
     windowSizeClass: WindowSizeClass,
     onNavigateToMainScreen: () -> Unit,
-    getCredentialManager: () -> CredentialManager,
+    credentialManager: CredentialManager,
     signInWithGoogleRequest: GetCredentialRequest,
 ) {
     val onLoginSuccess = {
@@ -176,7 +176,7 @@ fun NavGraphBuilder.blindarMainNavGraph(
             onFail = {
                 context.makeToast(failMessage)
             },
-            credentialManager = getCredentialManager(),
+            credentialManager = credentialManager,
             signInWithGoogleRequest = signInWithGoogleRequest,
             modifier = Modifier
                 .safeDrawingPadding()

--- a/app/src/main/java/com/practice/hanbitlunch/MainActivity.kt
+++ b/app/src/main/java/com/practice/hanbitlunch/MainActivity.kt
@@ -10,9 +10,12 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.WindowCompat
+import androidx.credentials.CredentialManager
+import androidx.credentials.GetCredentialRequest
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInClient
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
+import com.google.android.libraries.identity.googleid.GetSignInWithGoogleOption
 import com.practice.designsystem.theme.BlindarTheme
 import com.practice.firebase.R
 import com.practice.preferences.PreferencesRepository
@@ -26,6 +29,8 @@ class MainActivity : ComponentActivity() {
     @Inject
     lateinit var preferencesRepository: PreferencesRepository
 
+    private val credentialManager = CredentialManager.create(this)
+
     @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -38,10 +43,11 @@ class MainActivity : ComponentActivity() {
                 BlindarTheme {
                     BlindarNavHost(
                         windowSizeClass = windowSizeClass,
+                        getCredentialManager = { credentialManager },
+                        signInWithGoogleRequest = getSignInWithGoogleRequest(),
                         modifier = Modifier
 //                            .safeDrawingPadding()
                             .fillMaxSize(),
-                        googleSignInClient = getGoogleSignInClient(),
                         onNavigateToMainScreen = {
 //                            WindowCompat.setDecorFitsSystemWindows(window, true)
                         }
@@ -58,5 +64,16 @@ class MainActivity : ComponentActivity() {
             .requestEmail()
             .build()
         return GoogleSignIn.getClient(this, options)
+    }
+
+    private fun getSignInWithGoogleRequest(): GetCredentialRequest {
+        val webClientId = getString(R.string.web_client_id)
+        val signInWithGoogleOption = GetSignInWithGoogleOption.Builder(webClientId)
+            .build()
+
+        val request: GetCredentialRequest = GetCredentialRequest.Builder()
+            .addCredentialOption(signInWithGoogleOption)
+            .build()
+        return request
     }
 }

--- a/app/src/main/java/com/practice/hanbitlunch/MainActivity.kt
+++ b/app/src/main/java/com/practice/hanbitlunch/MainActivity.kt
@@ -10,11 +10,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.WindowCompat
-import androidx.credentials.CredentialManager
 import androidx.credentials.GetCredentialRequest
-import com.google.android.gms.auth.api.signin.GoogleSignIn
-import com.google.android.gms.auth.api.signin.GoogleSignInClient
-import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.google.android.libraries.identity.googleid.GetSignInWithGoogleOption
 import com.practice.designsystem.theme.BlindarTheme
 import com.practice.firebase.R
@@ -29,8 +25,6 @@ class MainActivity : ComponentActivity() {
     @Inject
     lateinit var preferencesRepository: PreferencesRepository
 
-    private val credentialManager = CredentialManager.create(this)
-
     @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -43,7 +37,6 @@ class MainActivity : ComponentActivity() {
                 BlindarTheme {
                     BlindarNavHost(
                         windowSizeClass = windowSizeClass,
-                        getCredentialManager = { credentialManager },
                         signInWithGoogleRequest = getSignInWithGoogleRequest(),
                         modifier = Modifier
 //                            .safeDrawingPadding()
@@ -55,15 +48,6 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
-    }
-
-    private fun getGoogleSignInClient(): GoogleSignInClient {
-        val webClientId = getString(R.string.web_client_id)
-        val options = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
-            .requestIdToken(webClientId)
-            .requestEmail()
-            .build()
-        return GoogleSignIn.getClient(this, options)
     }
 
     private fun getSignInWithGoogleRequest(): GetCredentialRequest {

--- a/benchmark/build.gradle.kts
+++ b/benchmark/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "com.example.benchmark"
-    compileSdk = 34
+    compileSdkPreview = "VanillaIceCream"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
@@ -21,7 +21,7 @@ android {
 
     defaultConfig {
         minSdk = 26
-        targetSdk = 34
+        targetSdk = 35
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/core/auth/build.gradle.kts
+++ b/core/auth/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 android {
     namespace = "com.practice.user"
-    compileSdk = 34
+    compileSdkPreview = "VanillaIceCream"
 
     defaultConfig {
         minSdk = 26

--- a/core/auth/src/main/java/com/practice/auth/RegisterManager.kt
+++ b/core/auth/src/main/java/com/practice/auth/RegisterManager.kt
@@ -1,8 +1,6 @@
 package com.practice.auth
 
 import android.app.Activity
-import android.content.Intent
-import com.google.android.gms.common.api.ApiException
 import com.google.android.gms.tasks.Task
 import com.google.firebase.FirebaseException
 import com.google.firebase.auth.AuthResult
@@ -51,25 +49,6 @@ class RegisterManager @Inject constructor(
     ) {
         val user = BlindarFirebase.signInWithGoogle(idToken)
         checkGoogleRegisterStatus(user, onNewUserSignUp, onExistingUserLogin, onFail)
-    }
-
-    suspend fun parseIntentAndSignInWithGoogle(
-        intent: Intent,
-        onNewUserSignUp: (FirebaseUser) -> Unit,
-        onExistingUserLogin: (FirebaseUser) -> Unit,
-        onFail: () -> Unit,
-    ) {
-        try {
-            val firebaseUser = BlindarFirebase.signInWithGoogle(intent)
-            checkGoogleRegisterStatus(
-                user = firebaseUser,
-                onNewUserSignUp = onNewUserSignUp,
-                onExistingUserLogin = onExistingUserLogin,
-                onFail = onFail,
-            )
-        } catch (e: ApiException) {
-            onFail()
-        }
     }
 
     private suspend fun checkGoogleRegisterStatus(

--- a/core/auth/src/main/java/com/practice/auth/RegisterManager.kt
+++ b/core/auth/src/main/java/com/practice/auth/RegisterManager.kt
@@ -2,7 +2,6 @@ package com.practice.auth
 
 import android.app.Activity
 import android.content.Intent
-import android.util.Log
 import com.google.android.gms.common.api.ApiException
 import com.google.android.gms.tasks.Task
 import com.google.firebase.FirebaseException
@@ -42,6 +41,16 @@ class RegisterManager @Inject constructor(
             BlindarFirebase.getSchoolCode(firebaseUser.displayName!!) == null -> UserRegisterState.SCHOOL_NOT_SELECTED
             else -> UserRegisterState.ALL_FILLED
         }
+    }
+
+    suspend fun signInWithGoogle(
+        idToken: String,
+        onNewUserSignUp: (FirebaseUser) -> Unit,
+        onExistingUserLogin: (FirebaseUser) -> Unit,
+        onFail: () -> Unit,
+    ) {
+        val user = BlindarFirebase.signInWithGoogle(idToken)
+        checkGoogleRegisterStatus(user, onNewUserSignUp, onExistingUserLogin, onFail)
     }
 
     suspend fun parseIntentAndSignInWithGoogle(

--- a/core/combine/build.gradle.kts
+++ b/core/combine/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 android {
     namespace = "com.practice.combine"
-    compileSdk = 34
+    compileSdkPreview = "VanillaIceCream"
 
     defaultConfig {
         minSdk = 26

--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "com.practice.designsystem"
-    compileSdk = 34
+    compileSdkPreview = "VanillaIceCream"
 
     defaultConfig {
         minSdk = 26

--- a/core/designsystem/src/main/java/com/practice/designsystem/components/BlindarButton.kt
+++ b/core/designsystem/src/main/java/com/practice/designsystem/components/BlindarButton.kt
@@ -35,6 +35,7 @@ fun BlindarButton(
         color = MaterialTheme.colorScheme.primaryContainer,
     ),
     isPrimary: Boolean = true,
+    enabled: Boolean = true,
     content: @Composable RowScope.() -> Unit = {},
 ) {
     val containerColor by animateColorAsState(
@@ -49,6 +50,7 @@ fun BlindarButton(
         colors = ButtonDefaults.buttonColors(containerColor = containerColor),
         border = border,
         shape = shape,
+        enabled = enabled,
     ) {
         CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.onPrimaryContainer) {
             content()

--- a/core/firebase/build.gradle.kts
+++ b/core/firebase/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "com.practice.firebase"
-    compileSdk = 34
+    compileSdkPreview = "VanillaIceCream"
 
     defaultConfig {
         minSdk = 26
@@ -51,6 +51,9 @@ dependencies {
     api(platform(libs.firebase.bom))
     api(libs.firebase.auth.ktx)
     api(libs.firebase.database)
+
+    // androidx credential manager
+    api(libs.bundles.androidx.credentials)
 
     // KTX libraries
     implementation(libs.androidx.core.ktx)

--- a/core/firebase/src/main/java/com/practice/firebase/BlindarFirebase.kt
+++ b/core/firebase/src/main/java/com/practice/firebase/BlindarFirebase.kt
@@ -31,7 +31,7 @@ object BlindarFirebase {
         return signInWithGoogle(idToken = account.idToken)
     }
 
-    private suspend fun signInWithGoogle(idToken: String?): FirebaseUser? {
+    suspend fun signInWithGoogle(idToken: String?): FirebaseUser? {
         val firebaseCredential = GoogleAuthProvider.getCredential(idToken, null)
         val task = try {
             auth.signInWithCredential(firebaseCredential).await()

--- a/core/firebase/src/main/java/com/practice/firebase/BlindarFirebase.kt
+++ b/core/firebase/src/main/java/com/practice/firebase/BlindarFirebase.kt
@@ -1,12 +1,9 @@
 package com.practice.firebase
 
 import android.app.Activity
-import android.content.Intent
-import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.tasks.Task
 import com.google.firebase.auth.AuthResult
 import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.auth.FirebaseAuthInvalidCredentialsException
 import com.google.firebase.auth.FirebaseUser
 import com.google.firebase.auth.GoogleAuthProvider
 import com.google.firebase.auth.PhoneAuthCredential
@@ -25,11 +22,6 @@ object BlindarFirebase {
     private const val TAG = "BlindarFirebase"
     private val auth: FirebaseAuth = Firebase.auth
     private val database: DatabaseReference = Firebase.database.reference
-
-    suspend fun signInWithGoogle(intent: Intent): FirebaseUser? {
-        val account = GoogleSignIn.getSignedInAccountFromIntent(intent).await()
-        return signInWithGoogle(idToken = account.idToken)
-    }
 
     suspend fun signInWithGoogle(idToken: String?): FirebaseUser? {
         val firebaseCredential = GoogleAuthProvider.getCredential(idToken, null)
@@ -62,26 +54,6 @@ object BlindarFirebase {
             .setCallbacks(callback)
             .build()
         PhoneAuthProvider.verifyPhoneNumber(options)
-    }
-
-    fun signInWithPhoneAuthCredential(
-        activity: Activity,
-        credential: PhoneAuthCredential,
-        onRegisterOrLoginSuccessful: () -> Unit,
-        onLoginFail: () -> Unit,
-    ) {
-        auth.signInWithCredential(credential)
-            .addOnCompleteListener(activity) { task ->
-                val user = task.result?.user
-                if (task.isSuccessful && user != null) {
-                    onRegisterOrLoginSuccessful()
-                } else {
-                    if (task.exception is FirebaseAuthInvalidCredentialsException) {
-                        // verification code invalid
-                        onLoginFail()
-                    }
-                }
-            }
     }
 
     fun trySignInWithPhoneAuthCredential(

--- a/core/notification/build.gradle.kts
+++ b/core/notification/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "com.practice.notification"
-    compileSdk = 34
+    compileSdkPreview = "VanillaIceCream"
 
     defaultConfig {
         minSdk = 26

--- a/core/util/build.gradle.kts
+++ b/core/util/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "com.practice.util"
-    compileSdk = 34
+    compileSdkPreview = "VanillaIceCream"
 
     defaultConfig {
         minSdk = 26

--- a/core/work/build.gradle.kts
+++ b/core/work/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 
 android {
     namespace = "com.example.work"
-    compileSdk = 34
+    compileSdkPreview = "VanillaIceCream"
 
     defaultConfig {
         minSdk = 26

--- a/data/api/build.gradle.kts
+++ b/data/api/build.gradle.kts
@@ -12,7 +12,7 @@ val url: String = gradleLocalProperties(rootDir, providers).getProperty("server.
 
 android {
     namespace = "com.practice.api"
-    compileSdk = 34
+    compileSdkPreview = "VanillaIceCream"
 
     defaultConfig {
         minSdk = 26

--- a/data/api/src/main/java/com/practice/api/feedback/FeedbackRequest.kt
+++ b/data/api/src/main/java/com/practice/api/feedback/FeedbackRequest.kt
@@ -1,0 +1,7 @@
+package com.practice.api.feedback
+
+data class FeedbackRequest(
+    val userId: String,
+    val feedback: String,
+    val appVersionName: String,
+)

--- a/data/api/src/main/java/com/practice/api/feedback/RemoteFeedbackRepository.kt
+++ b/data/api/src/main/java/com/practice/api/feedback/RemoteFeedbackRepository.kt
@@ -1,5 +1,6 @@
 package com.practice.api.feedback
 
+import android.os.Build
 import com.practice.api.feedback.repository.FeedbackResult
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -9,6 +10,17 @@ class RemoteFeedbackRepository(
     private val dataStore: RemoteFeedbackDataStore,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
 ) {
+    suspend fun sendFeedback(request: FeedbackRequest): FeedbackResult {
+        return sendFeedback(
+            userId = request.userId,
+            deviceName = Build.MODEL,
+            osVersion = Build.VERSION.SDK_INT.toString(),
+            appVersion = request.appVersionName,
+            contents = request.feedback,
+        )
+    }
+
+    // TODO: 이거 private으로 전환하고, 사용자 id 얻는 과정 일원화하기
     suspend fun sendFeedback(
         userId: String,
         deviceName: String,

--- a/data/domain/build.gradle.kts
+++ b/data/domain/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "com.practice.domain"
-    compileSdk = 34
+    compileSdkPreview = "VanillaIceCream"
 
     defaultConfig {
         minSdk = 26

--- a/data/meal/build.gradle.kts
+++ b/data/meal/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 android {
     namespace = "com.practice.meal"
-    compileSdk = 34
+    compileSdkPreview = "VanillaIceCream"
 
     defaultConfig {
         minSdk = 26

--- a/data/memo/build.gradle.kts
+++ b/data/memo/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 android {
     namespace = "com.practice.memo"
-    compileSdk = 34
+    compileSdkPreview = "VanillaIceCream"
 
     defaultConfig {
         minSdk = 26

--- a/data/preferences/build.gradle.kts
+++ b/data/preferences/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 android {
     namespace = "com.practice.preferences"
-    compileSdk = 34
+    compileSdkPreview = "VanillaIceCream"
 
     defaultConfig {
         minSdk = 26

--- a/data/schedule/build.gradle.kts
+++ b/data/schedule/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 android {
     namespace = "com.practice.schedule"
-    compileSdk = 34
+    compileSdkPreview = "VanillaIceCream"
 
     defaultConfig {
         minSdk = 26

--- a/feature/main/build.gradle.kts
+++ b/feature/main/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 android {
     namespace = "com.practice.main"
-    compileSdk = 34
+    compileSdkPreview = "VanillaIceCream"
 
     defaultConfig {
         minSdk = 26

--- a/feature/onboarding/build.gradle.kts
+++ b/feature/onboarding/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 android {
     namespace = "com.practice.onboarding"
-    compileSdk = 34
+    compileSdkPreview = "VanillaIceCream"
 
     defaultConfig {
         minSdk = 26

--- a/feature/onboarding/src/main/java/com/practice/onboarding/onboarding/LoginErrorDialog.kt
+++ b/feature/onboarding/src/main/java/com/practice/onboarding/onboarding/LoginErrorDialog.kt
@@ -1,0 +1,104 @@
+package com.practice.onboarding.onboarding
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.practice.designsystem.DarkPreview
+import com.practice.designsystem.components.BlindarButton
+import com.practice.designsystem.components.BlindarDialog
+import com.practice.designsystem.components.BodyLarge
+import com.practice.designsystem.components.TitleMedium
+import com.practice.designsystem.theme.BlindarTheme
+import com.practice.onboarding.R
+
+@Composable
+fun LoginErrorDialog(
+    isSendButtonEnabled: Boolean,
+    onDismiss: () -> Unit,
+    onSendLog: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    BlindarDialog(
+        onDismissRequest = onDismiss,
+        modifier = modifier
+            .clip(RoundedCornerShape(16.dp))
+            .background(MaterialTheme.colorScheme.surface),
+    ) {
+        Column {
+            CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.onSurface) {
+                Column(
+                    modifier = Modifier.padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                ) {
+                    TitleMedium(text = stringResource(id = R.string.login_error_dialog_title))
+                    BodyLarge(text = stringResource(id = R.string.login_error_dialog_body))
+                    BodyLarge(text = stringResource(id = R.string.login_error_dialog_caption))
+                }
+            }
+            LoginErrorDialogButtons(
+                isSendButtonEnabled = isSendButtonEnabled,
+                onCancel = onDismiss,
+                onConfirm = onSendLog,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun LoginErrorDialogButtons(
+    isSendButtonEnabled: Boolean,
+    onCancel: () -> Unit,
+    onConfirm: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(modifier = modifier) {
+        BlindarButton(
+            onClick = onCancel,
+            modifier = Modifier.weight(1f),
+            isPrimary = false,
+        ) {
+            BodyLarge(
+                text = stringResource(id = R.string.login_error_dialog_cancel),
+                modifier = Modifier.padding(6.dp),
+            )
+        }
+        BlindarButton(
+            onClick = onConfirm,
+            modifier = Modifier.weight(1f),
+            enabled = isSendButtonEnabled,
+        ) {
+            BodyLarge(
+                text = stringResource(id = R.string.login_error_dialog_confirm),
+                modifier = Modifier.padding(6.dp),
+            )
+        }
+    }
+}
+
+@DarkPreview
+@Composable
+private fun LoginErrorDialogPreview() {
+    BlindarTheme {
+        LoginErrorDialog(
+            isSendButtonEnabled = true,
+            onDismiss = {},
+            onSendLog = {},
+            modifier = Modifier
+                .padding(16.dp)
+                .fillMaxWidth(),
+        )
+    }
+}

--- a/feature/onboarding/src/main/java/com/practice/onboarding/onboarding/OnboardingScreen.kt
+++ b/feature/onboarding/src/main/java/com/practice/onboarding/onboarding/OnboardingScreen.kt
@@ -1,6 +1,5 @@
 package com.practice.onboarding.onboarding
 
-import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -88,16 +87,17 @@ fun OnboardingScreen(
             GoogleLoginButton(
                 onGoogleLogin = {
                     coroutineScope.launch {
-                        val result = credentialManager.getCredential(
-                            context = context.applicationContext,
+                        val result = viewModel.getCredential(
+                            context = context,
+                            credentialManager = credentialManager,
                             request = signInWithGoogleRequest,
                         )
-                        Log.d("OnboardingScreen", "${result.credential.type}")
                         viewModel.parseIdToken(
-                            result = result,
+                            result = result ?: return@launch,
                             onNewUserSignUp = onNewUserSignUp,
                             onExistingUserLogin = onExistingUserLogin,
                             onFail = onFail,
+                            context = context,
                         )
                     }
                 },

--- a/feature/onboarding/src/main/java/com/practice/onboarding/onboarding/OnboardingScreen.kt
+++ b/feature/onboarding/src/main/java/com/practice/onboarding/onboarding/OnboardingScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -31,6 +32,7 @@ import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.credentials.CredentialManager
 import androidx.credentials.GetCredentialRequest
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.firebase.auth.FirebaseUser
 import com.practice.designsystem.LightPreview
 import com.practice.designsystem.LightTabletPreview
@@ -42,6 +44,7 @@ import com.practice.onboarding.onboarding.animation.animateAppIconOffset
 import com.practice.onboarding.onboarding.animation.animateButtonAlpha
 import com.practice.onboarding.onboarding.animation.getAppIconOffset
 import com.practice.onboarding.onboarding.animation.getButtonAlpha
+import com.practice.util.getAppVersionName
 import kotlinx.coroutines.launch
 
 @Composable
@@ -122,6 +125,18 @@ fun OnboardingScreen(
                     .alpha(buttonAlpha.value),
             )
         }
+    }
+
+    val exception by viewModel.loginException.collectAsStateWithLifecycle()
+    val sendLogEnabled by viewModel.sendLogEnabled.collectAsStateWithLifecycle()
+    if (exception != null) {
+        LoginErrorDialog(
+            isSendButtonEnabled = sendLogEnabled,
+            onDismiss = viewModel::hideErrorDialog,
+            onSendLog = {
+                viewModel.sendFeedback(appVersionName = context.getAppVersionName())
+            },
+        )
     }
 }
 

--- a/feature/onboarding/src/main/java/com/practice/onboarding/onboarding/OnboardingScreen.kt
+++ b/feature/onboarding/src/main/java/com/practice/onboarding/onboarding/OnboardingScreen.kt
@@ -1,11 +1,6 @@
 package com.practice.onboarding.onboarding
 
-import android.app.Activity
-import android.content.Intent
 import android.util.Log
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.ActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -64,20 +59,6 @@ fun OnboardingScreen(
 ) {
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
-    val startForResult = rememberGoogleLoginRequestLauncher(
-        onGoogleLogin = { intent ->
-            coroutineScope.launch {
-                viewModel.tryGoogleLogin(
-                    context = context,
-                    intent = intent,
-                    onNewUserSignUp = onNewUserSignUp,
-                    onExistingUserLogin = onExistingUserLogin,
-                    onFail = onFail,
-                )
-            }
-        },
-        onFail = { },
-    )
 
     val appIconOffset = getAppIconOffset(playAnimation = route.playAnimation)
     val buttonAlpha = getButtonAlpha(playAnimation = route.playAnimation)
@@ -143,19 +124,6 @@ fun OnboardingScreen(
         }
     }
 }
-
-@Composable
-private fun rememberGoogleLoginRequestLauncher(
-    onGoogleLogin: (Intent) -> Unit,
-    onFail: (ActivityResult) -> Unit,
-) =
-    rememberLauncherForActivityResult(contract = ActivityResultContracts.StartActivityForResult()) { result ->
-        if (result.resultCode == Activity.RESULT_OK) {
-            result.data?.let(onGoogleLogin)
-        } else {
-            onFail(result)
-        }
-    }
 
 @Composable
 private fun PhoneLoginButton(

--- a/feature/onboarding/src/main/java/com/practice/onboarding/onboarding/OnboardingViewModel.kt
+++ b/feature/onboarding/src/main/java/com/practice/onboarding/onboarding/OnboardingViewModel.kt
@@ -2,11 +2,17 @@ package com.practice.onboarding.onboarding
 
 import android.content.Context
 import android.content.Intent
+import androidx.credentials.CustomCredential
+import androidx.credentials.GetCredentialResponse
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
+import com.google.android.libraries.identity.googleid.GoogleIdTokenParsingException
 import com.google.firebase.auth.FirebaseUser
 import com.practice.auth.RegisterManager
 import com.practice.work.BlindarWorkManager
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -31,6 +37,45 @@ class OnboardingViewModel @Inject constructor(
             },
             onFail = onFail
         )
+    }
+
+    /* 위에 있는 코드는 레거시 */
+
+    fun parseIdToken(
+        result: GetCredentialResponse,
+        onNewUserSignUp: (FirebaseUser) -> Unit,
+        onExistingUserLogin: (FirebaseUser) -> Unit,
+        onFail: () -> Unit,
+    ) {
+        when (val credential = result.credential) {
+            is CustomCredential -> {
+                if (credential.type == GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL) {
+                    try {
+                        val googleIdTokenCredential =
+                            GoogleIdTokenCredential.createFrom(credential.data)
+                        signInWithGoogle(
+                            idToken = googleIdTokenCredential.idToken,
+                            onNewUserSignUp = onNewUserSignUp,
+                            onExistingUserLogin = onExistingUserLogin,
+                            onFail = onFail,
+                        )
+                    } catch (e: GoogleIdTokenParsingException) {
+                        e.printStackTrace()
+                    }
+                }
+            }
+        }
+    }
+
+    private fun signInWithGoogle(
+        idToken: String,
+        onNewUserSignUp: (FirebaseUser) -> Unit,
+        onExistingUserLogin: (FirebaseUser) -> Unit,
+        onFail: () -> Unit,
+    ) {
+        viewModelScope.launch {
+            registerManager.signInWithGoogle(idToken, onNewUserSignUp, onExistingUserLogin, onFail)
+        }
     }
 
     companion object {

--- a/feature/onboarding/src/main/java/com/practice/onboarding/onboarding/OnboardingViewModel.kt
+++ b/feature/onboarding/src/main/java/com/practice/onboarding/onboarding/OnboardingViewModel.kt
@@ -1,7 +1,12 @@
 package com.practice.onboarding.onboarding
 
+import android.content.Context
+import android.util.Log
+import androidx.credentials.CredentialManager
 import androidx.credentials.CustomCredential
+import androidx.credentials.GetCredentialRequest
 import androidx.credentials.GetCredentialResponse
+import androidx.credentials.exceptions.GetCredentialCancellationException
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
@@ -16,6 +21,22 @@ import javax.inject.Inject
 class OnboardingViewModel @Inject constructor(
     private val registerManager: RegisterManager,
 ) : ViewModel() {
+
+    suspend fun getCredential(
+        context: Context,
+        credentialManager: CredentialManager,
+        request: GetCredentialRequest,
+    ): GetCredentialResponse? {
+        return try {
+            credentialManager.getCredential(
+                context = context,
+                request = request,
+            )
+        } catch (e: GetCredentialCancellationException) {
+            e.printStackTrace()
+            null
+        }
+    }
 
     fun parseIdToken(
         result: GetCredentialResponse,

--- a/feature/onboarding/src/main/java/com/practice/onboarding/onboarding/OnboardingViewModel.kt
+++ b/feature/onboarding/src/main/java/com/practice/onboarding/onboarding/OnboardingViewModel.kt
@@ -1,7 +1,5 @@
 package com.practice.onboarding.onboarding
 
-import android.content.Context
-import android.content.Intent
 import androidx.credentials.CustomCredential
 import androidx.credentials.GetCredentialResponse
 import androidx.lifecycle.ViewModel
@@ -10,7 +8,6 @@ import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import com.google.android.libraries.identity.googleid.GoogleIdTokenParsingException
 import com.google.firebase.auth.FirebaseUser
 import com.practice.auth.RegisterManager
-import com.practice.work.BlindarWorkManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -19,27 +16,6 @@ import javax.inject.Inject
 class OnboardingViewModel @Inject constructor(
     private val registerManager: RegisterManager,
 ) : ViewModel() {
-
-    suspend fun tryGoogleLogin(
-        context: Context,
-        intent: Intent,
-        onNewUserSignUp: (FirebaseUser) -> Unit,
-        onExistingUserLogin: (FirebaseUser) -> Unit,
-        onFail: () -> Unit,
-    ) {
-        registerManager.parseIntentAndSignInWithGoogle(
-            intent = intent,
-            onNewUserSignUp = onNewUserSignUp,
-            onExistingUserLogin = {
-                onExistingUserLogin(it)
-                BlindarWorkManager.setOneTimeFetchDataWork(context)
-                BlindarWorkManager.setFetchMemoFromServerWork(context, it.uid)
-            },
-            onFail = onFail
-        )
-    }
-
-    /* 위에 있는 코드는 레거시 */
 
     fun parseIdToken(
         result: GetCredentialResponse,
@@ -74,6 +50,7 @@ class OnboardingViewModel @Inject constructor(
         onFail: () -> Unit,
     ) {
         viewModelScope.launch {
+            // TODO: 구글 로그인 후 데이터 work가 돌지 않는 문제 해결
             registerManager.signInWithGoogle(idToken, onNewUserSignUp, onExistingUserLogin, onFail)
         }
     }

--- a/feature/onboarding/src/main/res/values/strings.xml
+++ b/feature/onboarding/src/main/res/values/strings.xml
@@ -4,4 +4,11 @@
 
     <string name="sign_in_with_phone">전화번호로 시작하기</string>
     <string name="sign_in_with_google">Google로 시작하기</string>
+
+    <string name="login_error_dialog_title">로그인 에러</string>
+    <string name="login_error_dialog_body">에러 해결을 위해 서버에 로그를 전송할까요?</string>
+    <string name="login_error_dialog_caption">전송하는 정보는 다음과 같습니다.\n- 에러 종류\n- 기기 모델명\n- 안드로이드 버전\n- 앱 버전</string>
+
+    <string name="login_error_dialog_cancel">취소</string>
+    <string name="login_error_dialog_confirm">전송</string>
 </resources>

--- a/feature/register/build.gradle.kts
+++ b/feature/register/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 
 android {
     namespace = "com.practice.register"
-    compileSdk = 34
+    compileSdkPreview = "VanillaIceCream"
 
     defaultConfig {
         minSdk = 26

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 android {
     namespace = "com.practice.settings"
-    compileSdk = 34
+    compileSdkPreview = "VanillaIceCream"
 
     defaultConfig {
         minSdk = 26

--- a/feature/settings/src/main/java/com/practice/settings/feedback/FeedbackScreen.kt
+++ b/feature/settings/src/main/java/com/practice/settings/feedback/FeedbackScreen.kt
@@ -87,7 +87,7 @@ private fun FeedbackScreen(
     feedback: String,
     onFeedbackUpdate: (String) -> Unit,
     isError: Boolean,
-    onSend: (FeedbackUiRequest) -> Unit,
+    onSend: (UiFeedbackRequest) -> Unit,
     onCancel: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -115,7 +115,7 @@ private fun FeedbackScreen(
                     .fillMaxWidth(),
             )
             FeedbackButtons(
-                onSend = { onSend(FeedbackUiRequest(feedback, versionName)) },
+                onSend = { onSend(UiFeedbackRequest(feedback, versionName)) },
                 onDismiss = onCancel,
             )
         }

--- a/feature/settings/src/main/java/com/practice/settings/feedback/FeedbackViewModel.kt
+++ b/feature/settings/src/main/java/com/practice/settings/feedback/FeedbackViewModel.kt
@@ -1,7 +1,7 @@
 package com.practice.settings.feedback
 
-import android.os.Build
 import androidx.lifecycle.ViewModel
+import com.practice.api.feedback.FeedbackRequest
 import com.practice.api.feedback.RemoteFeedbackRepository
 import com.practice.api.feedback.repository.FeedbackResult
 import com.practice.firebase.BlindarFirebase
@@ -37,22 +37,18 @@ class FeedbackViewModel @Inject constructor(
         }
     }
 
-    suspend fun sendFeedback(request: FeedbackUiRequest): Boolean {
-        val (feedback, appVersionName) = request
+    suspend fun sendFeedback(request: UiFeedbackRequest): Boolean {
+        val (appVersionName, feedback) = request
         if (!canSendFeedback(request.feedback)) {
             return false
         }
 
-        val userId = getUserId() ?: return false
-        val deviceName = Build.MODEL ?: "UNKNOWN_DEVICE"
-        val osVersion = Build.VERSION.SDK_INT.toString()
-
         return feedbackRepository.sendFeedback(
-            userId = userId,
-            deviceName = deviceName,
-            osVersion = osVersion,
-            appVersion = appVersionName,
-            contents = feedback
+            FeedbackRequest(
+                userId = getUserId() ?: "",
+                feedback = feedback,
+                appVersionName = appVersionName,
+            )
         ) is FeedbackResult.Success
     }
 

--- a/feature/settings/src/main/java/com/practice/settings/feedback/UiFeedbackRequest.kt
+++ b/feature/settings/src/main/java/com/practice/settings/feedback/UiFeedbackRequest.kt
@@ -1,6 +1,6 @@
 package com.practice.settings.feedback
 
-data class FeedbackUiRequest(
-    val feedback: String,
+data class UiFeedbackRequest(
     val appVersionName: String,
+    val feedback: String,
 )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 accompanist = '0.32.0'
 compose-bom = "2024.06.00"
 coroutines = "1.8.1"
+credentials = '1.5.0-alpha02'
 firebase-bom = "33.1.1"
 hilt = "2.51.1"
 hsk-ktx = '1.0-beta17'
@@ -15,7 +16,7 @@ navigation = '2.8.0-beta04'
 work = "2.9.0"
 
 [libraries]
-android-gradle = "com.android.tools.build:gradle:8.4.0"
+android-gradle = "com.android.tools.build:gradle:8.5.0"
 hilt-android-gradle-plugin = { module = 'com.google.dagger:hilt-android-gradle-plugin', version.ref = 'hilt' }
 kotlin-gradle-plugin = { module = 'org.jetbrains.kotlin:kotlin-gradle-plugin', version.ref = 'kotlin' }
 kotlinx-serialization-plugin = { module = 'org.jetbrains.kotlin:kotlin-serialization', version.ref = 'kotlin' }
@@ -59,6 +60,10 @@ androidx-core-splashscreen = 'androidx.core:core-splashscreen:1.0.1'
 androidx-datastore-preferences = 'androidx.datastore:datastore-preferences:1.1.1'
 androidx-profileinstaller = 'androidx.profileinstaller:profileinstaller:1.3.1'
 androidx-startup-runtime = 'androidx.startup:startup-runtime:1.1.1'
+
+androidx-credentials = { module = 'androidx.credentials:credentials', version.ref = 'credentials' }
+androidx-credentials-play = { module = 'androidx.credentials:credentials-play-services-auth', version.ref = 'credentials' }
+android-identity = "com.google.android.libraries.identity.googleid:googleid:1.1.1"
 
 androidx-activity-compose = { module = 'androidx.activity:activity-compose' }
 androidx-hilt-navigation-compose = 'androidx.hilt:hilt-navigation-compose:1.2.0'
@@ -128,6 +133,11 @@ accompanist = [
     'accompanist-permission'
 ]
 android-test = ['androidx-junit', 'androidx-test-espresso-core']
+androidx-credentials = [
+    'androidx-credentials',
+    'androidx-credentials-play',
+    'android-identity'
+]
 compose = [
     'androidx-compose-foundation',
     'androidx-compose-material-icons-core',

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Feb 16 15:01:47 KST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Deprecated된 Sign in with Google을 [credential manager](https://developer.android.com/identity/sign-in/credential-manager)로 migrate하였다.

그런데 credential manager 코드가 에뮬레이터에서 거의 작동하지 않는다(exception이 매우 다채롭게 발생...). 내가 테스트한 실제 기기에서는 모두 작동했지만, 혹시 몰라서 에러 로그 전송 dialog를 추가하였다.

![Screenshot_20240703_153218](https://github.com/blinder-23/blindar-android/assets/45386920/bd510e14-0995-4a65-a44a-434ee79a4a52)

에러 dialog에서는 `Exception`의 stack trace와 메시지를 피드백으로 전송한다.