### PR TITLE
fix: 메인 화면에서 데이터가 제대로 업데이트되지 않던 문제 해결

### DIFF
--- a/core/designsystem/src/main/java/com/practice/designsystem/calendar/SwipeableCalendar.kt
+++ b/core/designsystem/src/main/java/com/practice/designsystem/calendar/SwipeableCalendar.kt
@@ -23,6 +23,7 @@ import com.practice.designsystem.calendar.core.offset
 import com.practice.designsystem.calendar.core.rememberCalendarState
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.flow.drop
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -43,10 +44,10 @@ fun SwipeableCalendar(
 ) {
     val currentYearMonth = YearMonth.now()
     val middlePage = itemCount / 2
-
     // Tracks swipe gesture
+    // Drop first page event (initial composition after composable is drawn)
     LaunchedEffect(true) {
-        snapshotFlow { pagerState.currentPage }.collect { pageIndex ->
+        snapshotFlow { pagerState.currentPage }.drop(1).collect { pageIndex ->
             onPageChange(pageIndex)
         }
     }

--- a/feature/main/src/main/java/com/practice/main/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/practice/main/main/MainScreen.kt
@@ -18,8 +18,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.practice.designsystem.a11y.isLargeFont
@@ -52,10 +50,6 @@ fun MainScreen(
         systemUiController.setStatusBarColor(systemBarColor)
         systemUiController.setNavigationBarColor(systemBarColor)
         onLaunch()
-    }
-
-    LifecycleEventEffect(event = Lifecycle.Event.ON_START) {
-        viewModel.onLaunch()
     }
 
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()

--- a/feature/main/src/main/java/com/practice/main/main/MainScreenViewModel.kt
+++ b/feature/main/src/main/java/com/practice/main/main/MainScreenViewModel.kt
@@ -208,7 +208,6 @@ class MainScreenViewModel @Inject constructor(
         return newDailyData
     }
 
-    // TODO: 이전 yearMonth에 따라 first 또는 last day로 이동 (weekday 아님!)
     fun onSwiped(yearMonth: YearMonth) {
         val firstWeekday = yearMonth.getFirstWeekday()
         selectedDate.update { firstWeekday }

--- a/feature/main/src/main/java/com/practice/main/main/MainScreenViewModel.kt
+++ b/feature/main/src/main/java/com/practice/main/main/MainScreenViewModel.kt
@@ -170,7 +170,7 @@ class MainScreenViewModel @Inject constructor(
         }
     }
 
-    fun onDateClick(clickedDate: Date) = viewModelScope.launch {
+    fun onDateClick(clickedDate: Date) {
         selectedDate.update { clickedDate }
         selectedMealIndex.update { 0 }
     }
@@ -183,7 +183,7 @@ class MainScreenViewModel @Inject constructor(
         )
     }
 
-    fun onMealTimeClick(index: Int) = viewModelScope.launch {
+    fun onMealTimeClick(index: Int) {
         selectedMealIndex.update { index }
     }
 
@@ -209,7 +209,7 @@ class MainScreenViewModel @Inject constructor(
     }
 
     // TODO: 이전 yearMonth에 따라 first 또는 last day로 이동 (weekday 아님!)
-    fun onSwiped(yearMonth: YearMonth) = viewModelScope.launch {
+    fun onSwiped(yearMonth: YearMonth) {
         val firstWeekday = yearMonth.getFirstWeekday()
         selectedDate.update { firstWeekday }
     }

--- a/feature/main/src/main/java/com/practice/main/main/MainScreenViewModel.kt
+++ b/feature/main/src/main/java/com/practice/main/main/MainScreenViewModel.kt
@@ -58,13 +58,14 @@ class MainScreenViewModel @Inject constructor(
     preferencesRepository: PreferencesRepository,
 ) : ViewModel() {
 
-    private val userId = getCurrentUserId()
+    private var initialWorkCount: Int? = null
 
     private val preferencesState: Flow<PreferencesState> =
         preferencesRepository.userPreferencesFlow.map {
             if (initialWorkCount == null) {
                 initialWorkCount = it.runningWorksCount
             }
+
             PreferencesState.Loaded(
                 isRefreshing = it.runningWorksCount != initialWorkCount,
                 selectedSchool = School(
@@ -74,6 +75,7 @@ class MainScreenViewModel @Inject constructor(
                 mainUiMode = it.mainScreenMode.toUiLoadedMode(),
             )
         }
+
     private val selectedDate = MutableStateFlow(Date.now())
     private val selectedYearMonth: Flow<YearMonth> = selectedDate.map {
         it.yearMonth
@@ -85,6 +87,8 @@ class MainScreenViewModel @Inject constructor(
 
     private var loadMonthlyDataJob: Job? = null
     private val monthlyData: MutableStateFlow<MonthlyData> = MutableStateFlow(MonthlyData.Empty)
+
+    private val userId = getCurrentUserId()
 
     val uiState: StateFlow<MainUiState> = combine(
         preferencesState,
@@ -117,8 +121,6 @@ class MainScreenViewModel @Inject constructor(
     // For internal use only
     private val state: MainUiState
         get() = uiState.value
-
-    private var initialWorkCount: Int? = null
 
     private fun getCurrentUserId(): String {
         return when (val currentlyLoggedInUser = BlindarFirebase.getBlindarUser()) {

--- a/feature/main/src/main/java/com/practice/main/main/MainScreenViewModel.kt
+++ b/feature/main/src/main/java/com/practice/main/main/MainScreenViewModel.kt
@@ -127,12 +127,8 @@ class MainScreenViewModel @Inject constructor(
         }
     }
 
-    /**
-     * init 블럭에서 실행하지 않은 이유는 [IllegalStateException]이 발생하기 때문이다.
-     * 아직 UI에 반영되지 않은 값을 참조하기 때문에 예외가 발생한다.
-     */
-    fun onLaunch() {
-        viewModelScope.launch {
+    init {
+        viewModelScope.launch(Dispatchers.IO) {
             collectMonthlyDataParameters()
         }
     }


### PR DESCRIPTION
https://blinder23.atlassian.net/browse/BLINDAR-100?atlOrigin=eyJpIjoiNzhjYzE2NmZmYjMxNDM4ODkyMzFiZWE4ZjQzMjdjNjUiLCJwIjoiaiJ9

## 문제 상황

모든 데이터가 정상적으로 DB에 저장되어 있음에도 불구하고, 오늘 날짜를 제외한 월의 데이터가 메인 화면에 보이지 않는다.

예를 들면, 이 PR을 올린 날이 7월이므로 7월 외의 데이터가 메인 화면에서 보이지 않는다.

## 해결 방법

선택된 날짜가 6월로 바뀌었음에도 7월 데이터를 계속 collect하고 있던 것이 문제였다. 따라서 선택한 날짜의 월이 바뀌었을 때 기존 collect 작업을 cancel하고, 새로운 날짜의 데이터를 collect하도록 수정했다.

그 밖에도 달력 화면에서 날짜가 무조건 1일로 고정되던 문제를 해결했다.

## 수정한 내용

* 93c3a5ef96691f67f8844b42f9c70c8ba05225b1: 위에서 설명한 문제 해결
* 353ba6b8346979792b91c09096aa8d0c974871f4: 달력 화면에서 날짜가 무조건 1일로 세팅되던 문제 해결
