### PR TITLE
Feature/log by text

### DIFF
--- a/app/src/main/java/com/practice/hanbitlunch/BlindarNavHost.kt
+++ b/app/src/main/java/com/practice/hanbitlunch/BlindarNavHost.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.IntOffset
 import androidx.credentials.CredentialManager
 import androidx.credentials.GetCredentialRequest
@@ -170,7 +169,6 @@ fun NavGraphBuilder.blindarMainNavGraph(
     composable<OnboardingRoute> { backStackEntry ->
         val route = backStackEntry.toRoute<OnboardingRoute>()
         val context = LocalContext.current
-        val failMessage = stringResource(id = R.string.google_login_fail_message)
         OnboardingScreen(
             route = route,
             onPhoneLogin = { navController.navigate(VerifyPhoneRoute) },
@@ -183,7 +181,7 @@ fun NavGraphBuilder.blindarMainNavGraph(
                 }
             },
             onFail = {
-                context.makeToast(failMessage)
+                context.makeToast(R.string.google_login_fail_message)
             },
             credentialManager = credentialManager,
             signInWithGoogleRequest = signInWithGoogleRequest,

--- a/core/util/src/main/java/com/practice/util/ToastUtil.kt
+++ b/core/util/src/main/java/com/practice/util/ToastUtil.kt
@@ -2,8 +2,12 @@ package com.practice.util
 
 import android.content.Context
 import android.widget.Toast
+import androidx.annotation.StringRes
 
-// TODO: StringRes만 있어도 만들 수 있게 수정
 fun Context.makeToast(message: String, duration: Int = Toast.LENGTH_LONG) {
     Toast.makeText(this, message, duration).show()
+}
+
+fun Context.makeToast(@StringRes stringId: Int, duration: Int = Toast.LENGTH_LONG) {
+    makeToast(getString(stringId), duration)
 }

--- a/feature/register/src/main/java/com/practice/register/phonenumber/VerifyPhoneNumber.kt
+++ b/feature/register/src/main/java/com/practice/register/phonenumber/VerifyPhoneNumber.kt
@@ -1,7 +1,5 @@
 package com.practice.register.phonenumber
 
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -11,12 +9,9 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.AssistChip
-import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
@@ -26,7 +21,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -38,7 +32,12 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.practice.designsystem.DarkPreview
 import com.practice.designsystem.LightPreview
-import com.practice.designsystem.components.*
+import com.practice.designsystem.components.BlindarChip
+import com.practice.designsystem.components.BlindarLargeTopAppBar
+import com.practice.designsystem.components.BlindarTopAppBarDefaults
+import com.practice.designsystem.components.BottomNextButton
+import com.practice.designsystem.components.LabelSmall
+import com.practice.designsystem.components.TitleSmall
 import com.practice.designsystem.theme.BlindarTheme
 import com.practice.register.R
 import com.practice.register.RegisterUiState
@@ -66,10 +65,7 @@ fun VerifyPhoneNumber(
     val activity = LocalActivity.current
     val context = LocalContext.current
 
-    val codeSentMessage = stringResource(id = R.string.auth_code_sent)
-    val invalidCodeMessage = stringResource(id = R.string.invalid_code)
-    val authFailMessage = stringResource(id = R.string.auth_code_fail)
-    val onCodeInvalid = { context.makeToast(invalidCodeMessage) }
+    val onCodeInvalid = { context.makeToast(R.string.invalid_code) }
     val verifyAuthCode = {
         viewModel.verifyAuthCode(
             activity = activity,
@@ -88,13 +84,13 @@ fun VerifyPhoneNumber(
         onAuthChipClick = {
             viewModel.onAuthChipClick(
                 activity = activity,
-                onCodeSent = { context.makeToast(codeSentMessage) },
+                onCodeSent = { context.makeToast(R.string.auth_code_sent) },
                 onNewUserSignUp = onNewUserSignUp,
                 onExistingUserLogin = onExistingUserLogin,
                 onUsernameNotSet = onUsernameNotSet,
                 onSchoolNotSelected = onSchoolNotSelected,
                 onCodeInvalid = onCodeInvalid,
-                onFail = { context.makeToast(authFailMessage) },
+                onFail = { context.makeToast(R.string.auth_code_fail) },
             )
         },
         onAuthCodeChange = viewModel::onAuthCodeChange,

--- a/feature/register/src/main/java/com/practice/register/registerform/RegisterFormScreen.kt
+++ b/feature/register/src/main/java/com/practice/register/registerform/RegisterFormScreen.kt
@@ -44,7 +44,6 @@ fun RegisterFormScreen(
 ) {
     val state by viewModel.registerUiState
     val context = LocalContext.current
-    val submitNameFailMessage = stringResource(R.string.submit_name_fail)
 
     RegisterFormScreen(
         state = state,
@@ -52,7 +51,7 @@ fun RegisterFormScreen(
         onSubmitName = {
             viewModel.submitName(
                 onSuccess = onNameUpdated,
-                onFail = { context.makeToast(submitNameFailMessage) },
+                onFail = { context.makeToast(R.string.submit_name_fail) },
             )
         },
         onNameChange = viewModel::onNameChange,

--- a/feature/settings/src/main/java/com/practice/settings/settings/DailyAlarmUtil.kt
+++ b/feature/settings/src/main/java/com/practice/settings/settings/DailyAlarmUtil.kt
@@ -4,14 +4,12 @@ import android.Manifest
 import android.app.AlarmManager
 import android.content.Context
 import android.os.Build
-import android.util.Log
 import android.widget.Toast
 import androidx.activity.compose.ManagedActivityResultLauncher
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.stringResource
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.getSystemService
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
@@ -27,14 +25,12 @@ internal fun rememberNotificationPermissionLauncher(
 ): ManagedActivityResultLauncher<String, Boolean> {
     val context = LocalContext.current
 
-    val permissionErrorMessage = stringResource(id = R.string.settings_daily_alarm_permission_error)
-    val dailyAlarmEnabledMessage = stringResource(id = R.string.settings_daily_alarm_enabled)
     val onPermissionGranted = {
         onToggle(!isDailyAlarmEnabled)
-        context.makeToast(dailyAlarmEnabledMessage, Toast.LENGTH_SHORT)
+        context.makeToast(R.string.settings_daily_alarm_enabled, Toast.LENGTH_SHORT)
     }
     val onPermissionDenied = {
-        context.makeToast(permissionErrorMessage, Toast.LENGTH_SHORT)
+        context.makeToast(R.string.settings_daily_alarm_permission_error, Toast.LENGTH_SHORT)
     }
 
     val exactAlarmPermissionState = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {


### PR DESCRIPTION
https://blinder23.atlassian.net/browse/BLINDAR-95?atlOrigin=eyJpIjoiY2U2MThhNmYyMWM0NDJkNDhlYWFkNDNkNWUwZTY5MWMiLCJwIjoiaiJ9

## 문제 상황

토스트 메시지를 만드는 확장 함수가 ``String``만을 매개변수로 받고 있어서, string resource id를 알고 있는 상황에서도 반드시 ``String``을 얻어야 했다.

## 해결 방법

String resource id를 매개변수로 받는 오버로딩을 추가했다.

```Kotlin
fun Context.makeToast(@StringRes stringId: Int, duration: Int = Toast.LENGTH_LONG) {
    makeToast(getString(stringId), duration)
}

fun Context.makeToast(message: String, duration: Int = Toast.LENGTH_LONG) {
    Toast.makeText(this, message, duration).show()
}
```

## 수정한 내용

* cb3d180e163813a9b2fb663457d06d19fe2f79af: string resource id를 받는 오버로딩 추가
* 8f9030cd5e23bfd49811ef826bb3e8274b907c97: resource id를 직접 사용할 수 있는 곳에서 새로 추가한 오버로딩을 사용