### PR TITLE
fix: 영양 화면이 스크롤되지 않던 문제 해결

### DIFF
--- a/feature/main/src/main/java/com/practice/main/nutrient/NutrientScreen.kt
+++ b/feature/main/src/main/java/com/practice/main/nutrient/NutrientScreen.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -128,8 +130,9 @@ private fun NutrientScreenSuccess(
     modifier: Modifier = Modifier,
 ) {
     val (calorie, major, minor) = sortAndSplitNutrients(uiState.nutrients)
+    val scrollState = rememberScrollState()
     Column(
-        modifier = modifier,
+        modifier = modifier.verticalScroll(scrollState),
         verticalArrangement = Arrangement.spacedBy(10.dp),
     ) {
         calorie.forEach {


### PR DESCRIPTION
## 문제 상황

영양 화면이 스크롤되지 않던 문제가 있었다.

## 해결 방법

`Column`은 기본적으로 스크롤되지 않는다. 따라서 `Modifier.verticalScroll()`를 추가하여 세로 스크롤 기능을 추가했다.

