### PR TITLE
feature: 중복된 사용자 이름과 조건에 맞지 않는 이름을 분리하여 보여줌

### DIFF
--- a/feature/register/src/main/java/com/practice/register/RegisterUiState.kt
+++ b/feature/register/src/main/java/com/practice/register/RegisterUiState.kt
@@ -1,8 +1,8 @@
 package com.practice.register
 
+import com.practice.domain.School
 import com.practice.register.phonenumber.PhoneNumberValidator
 import com.practice.register.registerform.NameValidator
-import com.practice.domain.School
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
@@ -12,6 +12,7 @@ data class RegisterUiState(
     val isAuthCodeFieldEnabled: Boolean,
     val isVerifyCodeButtonEnabled: Boolean,
     val name: String,
+    val isDuplicateName: Boolean,
     val selectedSchool: School,
     val schoolQuery: String,
     val schools: ImmutableList<School>,
@@ -29,6 +30,7 @@ data class RegisterUiState(
             isAuthCodeFieldEnabled = false,
             isVerifyCodeButtonEnabled = false,
             name = "",
+            isDuplicateName = false,
             selectedSchool = School.EmptySchool,
             schoolQuery = "",
             schools = persistentListOf(),

--- a/feature/register/src/main/java/com/practice/register/phonenumber/VerifyPhoneNumber.kt
+++ b/feature/register/src/main/java/com/practice/register/phonenumber/VerifyPhoneNumber.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.practice.designsystem.DarkPreview
 import com.practice.designsystem.LightPreview
@@ -61,7 +62,7 @@ fun VerifyPhoneNumber(
         systemUiController.setNavigationBarColor(navigationBarColor)
     }
 
-    val state by viewModel.registerUiState
+    val state by viewModel.registerUiState.collectAsStateWithLifecycle()
     val activity = LocalActivity.current
     val context = LocalContext.current
 

--- a/feature/register/src/main/java/com/practice/register/selectschool/SelectSchoolScreen.kt
+++ b/feature/register/src/main/java/com/practice/register/selectschool/SelectSchoolScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.practice.designsystem.LightAndDarkPreview
 import com.practice.designsystem.LightPreview
 import com.practice.designsystem.components.BlindarLargeTopAppBar
@@ -44,7 +45,7 @@ fun SelectSchoolScreen(
     modifier: Modifier = Modifier,
     viewModel: RegisterViewModel = hiltViewModel(),
 ) {
-    val uiState by viewModel.registerUiState
+    val uiState by viewModel.registerUiState.collectAsStateWithLifecycle()
 
     val context = LocalContext.current
     val baseSuccessMessage = stringResource(id = R.string.school_selected_base)

--- a/feature/register/src/main/res/values/strings.xml
+++ b/feature/register/src/main/res/values/strings.xml
@@ -16,7 +16,8 @@
 
     <string name="name_title">이름</string>
     <string name="name_placeholder">한글 15자, 영문, 숫자는 30자까지 가능합니다.</string>
-    <string name="submit_name_fail">조건에 맞지 않거나 중복된 이름입니다.</string>
+    <string name="username_invalid">조건에 맞지 않는 이름입니다.</string>
+    <string name="username_duplicate">중복된 사용자 이름입니다.</string>
 
     <string name="school_text_field_label">학교 검색</string>
     <string name="school_clear_text_field">검색창 비우기</string>


### PR DESCRIPTION
## 문제 상황

회원가입 중 사용자 이름을 입력받을 때에는 다음 두 가지 오류를 체크한다.

1. 잘못된 이름 (한글 15자, 영문/숫자 30자 이내)
2. 중복된 이름 (이미 사용중인 이름)

그런데 지금 앱에서는 1, 2번의 에러 메시지를 동일하게 보여주고 있어 사용자가 문제의 원인을 정확히 알기 어려웠다.

## 해결 방법

따라서 1, 2번 경우의 메시지를 다르게 표시해야 한다.

![image](https://github.com/user-attachments/assets/1d456b93-9a32-4e86-8241-ef1af01b1c48)
